### PR TITLE
Add file support to collections

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -10,3 +10,13 @@ HUTCH_API_KEY=
 # Defaults to http://localhost:3000. Self-hosters running behind a
 # reverse proxy or on a custom domain should set this explicitly.
 HUTCH_BASE_URL=http://localhost:3111
+
+# Optional: S3-compatible blob storage for the file tools (hutch_put_file).
+# Small UTF-8 text files are stored inline and need none of this; binary or
+# >256KB files require it (any S3-compatible endpoint: AWS S3, MinIO, R2, ...).
+HUTCH_S3_ENDPOINT=
+HUTCH_S3_BUCKET=
+HUTCH_S3_ACCESS_KEY_ID=
+HUTCH_S3_SECRET_ACCESS_KEY=
+# Optional; defaults to us-east-1 (use "auto" for R2/MinIO).
+HUTCH_S3_REGION=

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Core is intentionally small. If you want any of these, either run [Hutch Cloud](
 
 - **Next.js 16 App Router** — one static landing page, one MCP route (`/api/mcp`), one REST seed route (`/api/v1/collections`). Everything else is deleted.
 - **Drizzle + Postgres** — records stored as JSONB, queried via containment operators and full-text search.
-- **MCP server** — collection tools, record tools (store/query/search/update/delete/status/transform), schema tools (describe/infer/update), view tools.
+- **MCP server** — collection tools, record tools (store/query/search/update/delete/status/transform), schema tools (describe/infer/update), view tools, file tools (put/get/list — small text files store inline; binary or >256KB files use S3-compatible blob storage via the optional `HUTCH_S3_*` env vars).
 - **Auth seam** at `src/lib/auth/seam.ts` — if `HUTCH_API_KEY` is set, `authenticate()` requires a matching `Authorization: Bearer <key>`; otherwise it resolves the singleton context. The seam is the only place auth lives.
 - **Singleton bootstrap** at `src/lib/auth/singleton.ts` — one user, one personal org, inserted lazily on first request.
 

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -1,0 +1,38 @@
+# MinIO for the storage seam integration tests
+# (src/lib/storage/seam.integration.test.ts — see its header for the exact
+# env vars + npm test invocation).
+#
+#   Start:      docker compose -f docker-compose.minio.yml up -d --wait
+#   Tear down:  docker compose -f docker-compose.minio.yml down -v
+#
+# Kept separate from docker-compose.yml on purpose: this is test-only
+# infrastructure, not part of the self-hosted deployment.
+services:
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: hutch-test
+      MINIO_ROOT_PASSWORD: hutch-test-secret
+    ports:
+      # 9010 on the host to avoid colliding with anything already on 9000.
+      - "127.0.0.1:9010:9000"
+      # Web console (optional): http://127.0.0.1:9011
+      - "127.0.0.1:9011:9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 3s
+      timeout: 5s
+      retries: 10
+
+  # One-shot: creates the hutch-test bucket, then exits.
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 hutch-test hutch-test-secret &&
+      mc mb --ignore-existing local/hutch-test
+      "

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "hutch",
+  "name": "hutch-core",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hutch",
+      "name": "hutch-core",
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "aws4fetch": "^1.0.20",
         "drizzle-orm": "^0.45.2",
         "nanoid": "^5.1.9",
         "next": "16.2.3",
@@ -4458,6 +4459,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
     },
     "node_modules/axe-core": {
       "version": "4.11.3",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "db:migrate": "npx drizzle-kit migrate",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:integration": "HUTCH_S3_ENDPOINT=${HUTCH_S3_ENDPOINT:-http://127.0.0.1:9010} HUTCH_S3_BUCKET=${HUTCH_S3_BUCKET:-hutch-test} HUTCH_S3_ACCESS_KEY_ID=${HUTCH_S3_ACCESS_KEY_ID:-hutch-test} HUTCH_S3_SECRET_ACCESS_KEY=${HUTCH_S3_SECRET_ACCESS_KEY:-hutch-test-secret} HUTCH_S3_REGION=${HUTCH_S3_REGION:-auto} vitest run src/lib/storage/seam.integration.test.ts",
     "smoke": "npx tsx scripts/smoke.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "aws4fetch": "^1.0.20",
     "drizzle-orm": "^0.45.2",
     "nanoid": "^5.1.9",
     "next": "16.2.3",

--- a/src/app/api/v1/collections/[slug]/files/[...path]/route.test.ts
+++ b/src/app/api/v1/collections/[slug]/files/[...path]/route.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Failing spec (TDD) for the REST files route:
+//   src/app/api/v1/collections/[slug]/files/[...path]/route.ts
+//
+// PUT    — raw body bytes; mime from Content-Type (default
+//          application/octet-stream); 413 if > 4MB; upserts via putFile;
+//          200 with metadata JSON.
+// GET    — inline → body bytes with the file's Content-Type; blob → ALWAYS a
+//          302 redirect to the presigned download_url that getFile resolved
+//          via the storage seam (there is no byte-streaming path);
+//          missing → 404.
+// DELETE — soft-deletes; 200.
+// Auth via the existing authenticate(req) seam; 401 when it returns null.
+//
+// Next 16 route handlers receive ctx.params as a Promise.
+// ---------------------------------------------------------------------------
+
+const MAX_FILE_SIZE = 4_194_304
+
+const {
+  authenticateMock,
+  putFileMock,
+  getFileMock,
+  deleteFileMock,
+} = vi.hoisted(() => ({
+  authenticateMock: vi.fn(),
+  putFileMock: vi.fn(),
+  getFileMock: vi.fn(),
+  deleteFileMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/seam', () => ({
+  authenticate: authenticateMock,
+}))
+
+vi.mock('@/lib/services/files', () => ({
+  putFile: putFileMock,
+  getFile: getFileMock,
+  listFiles: vi.fn(),
+  deleteFile: deleteFileMock,
+  cleanupCollectionBlobs: vi.fn(),
+}))
+
+import { GET, PUT, DELETE } from './route'
+
+const presignedUrl =
+  'https://s3.example.test/hutch-blobs/blobs/1/abc?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=sig'
+
+const inlineFile = {
+  path: 'CLAUDE.md',
+  filename: 'CLAUDE.md',
+  mime_type: 'text/markdown',
+  size: 7,
+  content_hash: 'ab'.repeat(32),
+  content: '# hello',
+}
+
+const blobFile = {
+  path: 'logo.png',
+  filename: 'logo.png',
+  mime_type: 'image/png',
+  size: 4,
+  content_hash: 'cd'.repeat(32),
+  blob_key: 'blobs/1/abc',
+  download_url: presignedUrl,
+}
+
+function ctx(slug = 'agent-files', path: string[] = ['CLAUDE.md']) {
+  return { params: Promise.resolve({ slug, path }) }
+}
+
+function makeReq(method: string, opts: { body?: BodyInit; headers?: Record<string, string> } = {}): Request {
+  return new Request('http://localhost/api/v1/collections/agent-files/files/CLAUDE.md', {
+    method,
+    body: opts.body,
+    headers: opts.headers,
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  authenticateMock.mockResolvedValue({ userId: 'u1', orgId: 'o1' })
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('auth', () => {
+  it('PUT returns 401 when authenticate returns null', async () => {
+    authenticateMock.mockResolvedValue(null)
+    const res = await PUT(makeReq('PUT', { body: new Uint8Array([1]) }), ctx())
+    expect(res.status).toBe(401)
+    expect(putFileMock).not.toHaveBeenCalled()
+  })
+
+  it('GET returns 401 when authenticate returns null', async () => {
+    authenticateMock.mockResolvedValue(null)
+    const res = await GET(makeReq('GET'), ctx())
+    expect(res.status).toBe(401)
+    expect(getFileMock).not.toHaveBeenCalled()
+  })
+
+  it('DELETE returns 401 when authenticate returns null', async () => {
+    authenticateMock.mockResolvedValue(null)
+    const res = await DELETE(makeReq('DELETE'), ctx())
+    expect(res.status).toBe(401)
+    expect(deleteFileMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('PUT', () => {
+  it('upserts the raw body via putFile and returns 200 with metadata JSON', async () => {
+    putFileMock.mockResolvedValue(inlineFile)
+    const body = Buffer.from('# hello')
+
+    const res = await PUT(
+      makeReq('PUT', { body, headers: { 'content-type': 'text/markdown' } }),
+      ctx('agent-files', ['CLAUDE.md'])
+    )
+
+    expect(res.status).toBe(200)
+    expect(putFileMock).toHaveBeenCalledWith('u1', 'o1', expect.objectContaining({
+      collection: 'agent-files',
+      path: 'CLAUDE.md',
+      mimeType: 'text/markdown',
+    }))
+    // Raw request bytes travel losslessly to the service (base64 channel).
+    const params = putFileMock.mock.calls[0][2] as { contentBase64?: string }
+    expect(params.contentBase64).toBeDefined()
+    expect(Buffer.from(params.contentBase64!, 'base64').toString('utf8')).toBe('# hello')
+
+    const json = await res.json()
+    expect(json).toEqual(expect.objectContaining({
+      path: 'CLAUDE.md',
+      size: 7,
+      mime_type: 'text/markdown',
+      content_hash: inlineFile.content_hash,
+    }))
+    expect(json).not.toHaveProperty('content')
+  })
+
+  it('joins catch-all path segments with "/"', async () => {
+    putFileMock.mockResolvedValue({ ...inlineFile, path: 'prompts/reviewer.md', filename: 'reviewer.md' })
+
+    await PUT(
+      makeReq('PUT', { body: Buffer.from('x'), headers: { 'content-type': 'text/markdown' } }),
+      ctx('agent-files', ['prompts', 'reviewer.md'])
+    )
+
+    expect(putFileMock).toHaveBeenCalledWith('u1', 'o1', expect.objectContaining({
+      path: 'prompts/reviewer.md',
+    }))
+  })
+
+  it('defaults the mime type to application/octet-stream when Content-Type is absent', async () => {
+    putFileMock.mockResolvedValue(inlineFile)
+
+    await PUT(makeReq('PUT', { body: new Uint8Array([1, 2, 3]) }), ctx())
+
+    expect(putFileMock).toHaveBeenCalledWith('u1', 'o1', expect.objectContaining({
+      mimeType: 'application/octet-stream',
+    }))
+  })
+
+  it('returns 413 for a body over 4MB without calling the service', async () => {
+    const res = await PUT(
+      makeReq('PUT', { body: new Uint8Array(MAX_FILE_SIZE + 1) }),
+      ctx()
+    )
+
+    expect(res.status).toBe(413)
+    expect(putFileMock).not.toHaveBeenCalled()
+  })
+
+  it('maps service errors to their status code', async () => {
+    putFileMock.mockResolvedValue({ error: 'Invalid path', status: 400 })
+
+    const res = await PUT(makeReq('PUT', { body: Buffer.from('x') }), ctx())
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('GET', () => {
+  it('returns inline content as the body with the file Content-Type', async () => {
+    getFileMock.mockResolvedValue(inlineFile)
+
+    const res = await GET(makeReq('GET'), ctx('agent-files', ['CLAUDE.md']))
+
+    expect(getFileMock).toHaveBeenCalledWith('agent-files', 'u1', 'CLAUDE.md')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/markdown')
+    expect(await res.text()).toBe('# hello')
+  })
+
+  it('always 302-redirects a blob file to its presigned download_url', async () => {
+    getFileMock.mockResolvedValue(blobFile)
+
+    const res = await GET(makeReq('GET'), ctx('agent-files', ['logo.png']))
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe(presignedUrl)
+  })
+
+  it('maps a 501 storage-not-configured service error to a 501 response', async () => {
+    getFileMock.mockResolvedValue({
+      error: 'Blob storage is not configured. Set the HUTCH_S3_* environment variables.',
+      status: 501,
+    })
+
+    const res = await GET(makeReq('GET'), ctx('agent-files', ['logo.png']))
+    expect(res.status).toBe(501)
+  })
+
+  it('returns 404 when the file record is missing', async () => {
+    getFileMock.mockResolvedValue({ error: 'File not found', status: 404 })
+
+    const res = await GET(makeReq('GET'), ctx('agent-files', ['nope.md']))
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 when the collection is not accessible (service returns null)', async () => {
+    getFileMock.mockResolvedValue(null)
+
+    const res = await GET(makeReq('GET'), ctx('missing', ['x.md']))
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('DELETE', () => {
+  it('soft-deletes via deleteFile and returns 200', async () => {
+    deleteFileMock.mockResolvedValue({ deleted: true, path: 'CLAUDE.md' })
+
+    const res = await DELETE(makeReq('DELETE'), ctx('agent-files', ['CLAUDE.md']))
+
+    expect(deleteFileMock).toHaveBeenCalledWith('agent-files', 'u1', 'CLAUDE.md')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual(expect.objectContaining({ deleted: true }))
+  })
+
+  it('returns 404 when the file does not exist', async () => {
+    deleteFileMock.mockResolvedValue({ error: 'File not found', status: 404 })
+
+    const res = await DELETE(makeReq('DELETE'), ctx('agent-files', ['nope.md']))
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 when the collection is not accessible (service returns null)', async () => {
+    deleteFileMock.mockResolvedValue(null)
+
+    const res = await DELETE(makeReq('DELETE'), ctx('missing', ['x.md']))
+    expect(res.status).toBe(404)
+  })
+})

--- a/src/app/api/v1/collections/[slug]/files/[...path]/route.ts
+++ b/src/app/api/v1/collections/[slug]/files/[...path]/route.ts
@@ -11,14 +11,42 @@ import { MAX_FILE_SIZE } from "@/lib/constants";
 type Ctx = { params: Promise<{ slug: string; path: string[] }> };
 
 function json(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
+  return Response.json(body, { status });
 }
 
 function unauthorized(): Response {
   return json({ error: "Unauthorized" }, 401);
+}
+
+// Cap request-body buffering at MAX_FILE_SIZE: reject on the declared
+// Content-Length first, then abort mid-stream so a chunked upload can't
+// buffer unbounded bytes before the size check. Returns null when over cap.
+async function readBodyCapped(req: Request): Promise<Uint8Array | null> {
+  const declared = Number(req.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > MAX_FILE_SIZE) return null;
+
+  if (!req.body) return new Uint8Array(await req.arrayBuffer());
+
+  const reader = req.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_FILE_SIZE) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
 }
 
 export async function PUT(req: Request, ctx: Ctx) {
@@ -26,9 +54,9 @@ export async function PUT(req: Request, ctx: Ctx) {
   if (!auth) return unauthorized();
 
   const { slug, path } = await ctx.params;
-  const bytes = new Uint8Array(await req.arrayBuffer());
+  const bytes = await readBodyCapped(req);
 
-  if (bytes.byteLength > MAX_FILE_SIZE) {
+  if (bytes === null) {
     return json({ error: "File exceeds the 4MB size limit" }, 413);
   }
 
@@ -70,9 +98,15 @@ export async function GET(req: Request, ctx: Ctx) {
     });
   }
 
+  // nosniff + attachment: an attacker-chosen mime type (e.g. text/html) must
+  // not render or execute in-browser on this origin.
   return new Response(result.content, {
     status: 200,
-    headers: { "Content-Type": result.mime_type },
+    headers: {
+      "Content-Type": result.mime_type,
+      "X-Content-Type-Options": "nosniff",
+      "Content-Disposition": "attachment",
+    },
   });
 }
 

--- a/src/app/api/v1/collections/[slug]/files/[...path]/route.ts
+++ b/src/app/api/v1/collections/[slug]/files/[...path]/route.ts
@@ -1,0 +1,92 @@
+import { authenticate } from "@/lib/auth/seam";
+import { putFile, getFile, deleteFile } from "@/lib/services/files";
+import { MAX_FILE_SIZE } from "@/lib/constants";
+
+// REST files endpoint:
+//   PUT    — raw body bytes upsert via putFile (mime from Content-Type)
+//   GET    — inline files stream their bytes; blob files 302 to the presigned URL
+//   DELETE — soft-delete
+//
+// Next 16: ctx.params is a Promise.
+type Ctx = { params: Promise<{ slug: string; path: string[] }> };
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function unauthorized(): Response {
+  return json({ error: "Unauthorized" }, 401);
+}
+
+export async function PUT(req: Request, ctx: Ctx) {
+  const auth = await authenticate(req);
+  if (!auth) return unauthorized();
+
+  const { slug, path } = await ctx.params;
+  const bytes = new Uint8Array(await req.arrayBuffer());
+
+  if (bytes.byteLength > MAX_FILE_SIZE) {
+    return json({ error: "File exceeds the 4MB size limit" }, 413);
+  }
+
+  const result = await putFile(auth.userId, auth.orgId, {
+    collection: slug,
+    path: path.join("/"),
+    contentBase64: Buffer.from(bytes).toString("base64"),
+    mimeType: req.headers.get("content-type") ?? "application/octet-stream",
+  });
+
+  if ("error" in result) {
+    return json({ error: result.error }, result.status as number);
+  }
+
+  // Metadata only — never echo the content back.
+  const metadata: Record<string, unknown> = { ...result };
+  delete metadata.content;
+  delete metadata.blob_key;
+  return json(metadata, 200);
+}
+
+export async function GET(req: Request, ctx: Ctx) {
+  const auth = await authenticate(req);
+  if (!auth) return unauthorized();
+
+  const { slug, path } = await ctx.params;
+  const result = await getFile(slug, auth.userId, path.join("/"));
+
+  if (!result) return json({ error: "Collection not found" }, 404);
+  if ("error" in result) {
+    return json({ error: result.error }, result.status as number);
+  }
+
+  // Blob tier: ALWAYS redirect to the presigned URL — no byte-streaming path.
+  if ("download_url" in result) {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: result.download_url },
+    });
+  }
+
+  return new Response(result.content, {
+    status: 200,
+    headers: { "Content-Type": result.mime_type },
+  });
+}
+
+export async function DELETE(req: Request, ctx: Ctx) {
+  const auth = await authenticate(req);
+  if (!auth) return unauthorized();
+
+  const { slug, path } = await ctx.params;
+  const result = await deleteFile(slug, auth.userId, path.join("/"));
+
+  if (!result) return json({ error: "Collection not found" }, 404);
+  if ("error" in result) {
+    return json({ error: result.error }, result.status as number);
+  }
+
+  return json(result, 200);
+}

--- a/src/lib/constants.test.ts
+++ b/src/lib/constants.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { MAX_INLINE_FILE_SIZE, MAX_FILE_SIZE, MAX_RECORD_SIZE } from './constants'
+
+// Failing spec (TDD): file storage size constants.
+
+describe('file size constants', () => {
+  it('MAX_INLINE_FILE_SIZE is exactly 256KB (262_144 bytes)', () => {
+    expect(MAX_INLINE_FILE_SIZE).toBe(262_144)
+  })
+
+  it('MAX_FILE_SIZE is exactly 4MB (4_194_304 bytes)', () => {
+    expect(MAX_FILE_SIZE).toBe(4_194_304)
+  })
+
+  it('inline threshold is below the overall file cap and the record cap', () => {
+    expect(MAX_INLINE_FILE_SIZE).toBeLessThan(MAX_FILE_SIZE)
+    // Inline file content lives inside the record JSON, which is capped at
+    // MAX_RECORD_SIZE — the inline tier must fit within it.
+    expect(MAX_INLINE_FILE_SIZE).toBeLessThan(MAX_RECORD_SIZE)
+  })
+})

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,5 +13,10 @@ export const SIDEBAR_COLLECTION_LIMIT = 10;
 
 export const MAX_RECORD_SIZE = 1_000_000; // 1MB — enforced at the route and service layers
 
+// File storage tiers — inline content lives inside the record JSON (so it must
+// stay under MAX_RECORD_SIZE); anything bigger or binary goes to blob storage.
+export const MAX_INLINE_FILE_SIZE = 262_144; // 256KB — inline (in-record) file content cap
+export const MAX_FILE_SIZE = 4_194_304; // 4MB — overall file size cap (blob tier)
+
 export const FIELD_NAME_RE = /^[a-zA-Z0-9_]+$/;
 export const MAX_FIELD_NAME_LENGTH = 64;

--- a/src/lib/mcp/server-files.test.ts
+++ b/src/lib/mcp/server-files.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Failing spec (TDD) for the MCP file tools on src/lib/mcp/server.ts:
+//   hutch_put_file   {collection, path, content?, content_base64?, mime_type?}
+//   hutch_get_file   {collection, path}
+//   hutch_list_files {collection}
+// Mirrors the server.test.ts pattern, additionally capturing tool configs so
+// annotations (readOnlyHint / idempotentHint) can be asserted.
+// ---------------------------------------------------------------------------
+
+const { registeredTools, toolConfigs } = vi.hoisted(() => ({
+  registeredTools: new Map<string, (params: unknown) => Promise<unknown>>(),
+  toolConfigs: new Map<string, { annotations?: Record<string, unknown> }>(),
+}))
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
+  class McpServer {
+    registerTool(
+      name: string,
+      config: { annotations?: Record<string, unknown> },
+      handler: (params: unknown) => Promise<unknown>
+    ) {
+      registeredTools.set(name, handler)
+      toolConfigs.set(name, config)
+    }
+  }
+  return { McpServer }
+})
+
+vi.mock('@/lib/services/collections', () => ({
+  listCollections: vi.fn(),
+  getCollection: vi.fn(),
+  describeCollection: vi.fn(),
+  createCollection: vi.fn(),
+  updateCollection: vi.fn(),
+  deleteCollection: vi.fn(),
+  inferCollectionSchema: vi.fn(),
+  updateFieldDefinition: vi.fn(),
+}))
+
+vi.mock('@/lib/services/records', () => ({
+  createRecords: vi.fn(),
+  queryRecords: vi.fn(),
+  truncateRecords: vi.fn(),
+  updateRecord: vi.fn(),
+  transformRecords: vi.fn(),
+  updateRecordStatus: vi.fn(),
+  deleteRecord: vi.fn(),
+  searchGlobal: vi.fn(),
+}))
+
+vi.mock('@/lib/services/views', () => ({
+  createView: vi.fn(),
+}))
+
+vi.mock('@/lib/services/files', () => ({
+  putFile: vi.fn(),
+  getFile: vi.fn(),
+  listFiles: vi.fn(),
+  deleteFile: vi.fn(),
+  cleanupCollectionBlobs: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([]) })) })) })),
+  },
+}))
+
+import { createMcpServer } from './server'
+import * as fileService from '@/lib/services/files'
+
+const metadata = {
+  path: 'CLAUDE.md',
+  filename: 'CLAUDE.md',
+  mime_type: 'text/markdown',
+  size: 11,
+  content_hash: 'ab'.repeat(32),
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  registeredTools.clear()
+  toolConfigs.clear()
+})
+
+async function callTool(name: string, args: unknown): Promise<{ content: { text: string }[]; isError?: boolean }> {
+  const handler = registeredTools.get(name)
+  if (!handler) throw new Error(`tool ${name} not registered`)
+  return await handler(args) as { content: { text: string }[]; isError?: boolean }
+}
+
+describe('file tool registration', () => {
+  it('registers hutch_put_file, hutch_get_file, and hutch_list_files', () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    for (const name of ['hutch_put_file', 'hutch_get_file', 'hutch_list_files']) {
+      expect(registeredTools.has(name), `expected tool ${name} to be registered`).toBe(true)
+    }
+  })
+
+  it('marks hutch_put_file idempotent (same path + content converges)', () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    expect(toolConfigs.get('hutch_put_file')?.annotations).toEqual(
+      expect.objectContaining({ idempotentHint: true })
+    )
+  })
+
+  it('marks hutch_get_file and hutch_list_files read-only', () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    expect(toolConfigs.get('hutch_get_file')?.annotations).toEqual(
+      expect.objectContaining({ readOnlyHint: true })
+    )
+    expect(toolConfigs.get('hutch_list_files')?.annotations).toEqual(
+      expect.objectContaining({ readOnlyHint: true })
+    )
+  })
+})
+
+describe('hutch_put_file', () => {
+  it('forwards collection, path, content, and mime_type to fileService.putFile', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(fileService.putFile).mockResolvedValue(metadata as never)
+
+    await callTool('hutch_put_file', {
+      collection: 'agent-files',
+      path: 'CLAUDE.md',
+      content: '# hello',
+      mime_type: 'text/markdown',
+    })
+
+    expect(fileService.putFile).toHaveBeenCalledWith('user-1', 'org-test', expect.objectContaining({
+      collection: 'agent-files',
+      path: 'CLAUDE.md',
+      content: '# hello',
+      mimeType: 'text/markdown',
+    }))
+  })
+
+  it('maps content_base64 to the service contentBase64 param', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(fileService.putFile).mockResolvedValue(metadata as never)
+    const b64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64')
+
+    await callTool('hutch_put_file', {
+      collection: 'agent-files',
+      path: 'logo.png',
+      content_base64: b64,
+      mime_type: 'image/png',
+    })
+
+    expect(fileService.putFile).toHaveBeenCalledWith('user-1', 'org-test', expect.objectContaining({
+      contentBase64: b64,
+      mimeType: 'image/png',
+    }))
+  })
+
+  it('returns the file metadata as JSON, without echoing content', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(fileService.putFile).mockResolvedValue(metadata as never)
+
+    const result = await callTool('hutch_put_file', {
+      collection: 'agent-files',
+      path: 'CLAUDE.md',
+      content: '# hello',
+    })
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed).toEqual(expect.objectContaining({
+      path: 'CLAUDE.md',
+      size: 11,
+      content_hash: metadata.content_hash,
+    }))
+    expect(parsed).not.toHaveProperty('content')
+  })
+
+  it('returns isError with a clear message when the file exceeds 4MB', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(fileService.putFile).mockResolvedValue({
+      error: 'File exceeds the 4MB size limit',
+      status: 413,
+    } as never)
+
+    const result = await callTool('hutch_put_file', {
+      collection: 'agent-files',
+      path: 'huge.bin',
+      content_base64: 'AAAA',
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toMatch(/4\s?MB/i)
+  })
+
+  it('returns isError with a clear message when blob storage is not configured', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(fileService.putFile).mockResolvedValue({
+      error: 'Blob storage is not configured. Set the HUTCH_S3_* environment variables.',
+      status: 501,
+    } as never)
+
+    const result = await callTool('hutch_put_file', {
+      collection: 'agent-files',
+      path: 'logo.png',
+      content_base64: Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'),
+      mime_type: 'image/png',
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toMatch(/not configured/i)
+  })
+
+  it('returns isError with the validation message for a bad path', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(fileService.putFile).mockResolvedValue({
+      error: "Invalid path: must be a relative path without '..' segments",
+      status: 400,
+    } as never)
+
+    const result = await callTool('hutch_put_file', {
+      collection: 'agent-files',
+      path: '../escape.md',
+      content: 'x',
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toMatch(/path/i)
+  })
+})
+
+describe('hutch_get_file', () => {
+  it('forwards collection and path to fileService.getFile', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(fileService.getFile).mockResolvedValue({ ...metadata, content: '# hello' } as never)
+
+    await callTool('hutch_get_file', { collection: 'agent-files', path: 'CLAUDE.md' })
+
+    expect(fileService.getFile).toHaveBeenCalledWith('agent-files', 'user-1', 'CLAUDE.md')
+  })
+
+  it('returns the content for an inline file', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(fileService.getFile).mockResolvedValue({ ...metadata, content: '# hello' } as never)
+
+    const result = await callTool('hutch_get_file', { collection: 'agent-files', path: 'CLAUDE.md' })
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed).toEqual(expect.objectContaining({ path: 'CLAUDE.md', content: '# hello' }))
+  })
+
+  it('returns the presigned download_url for a blob file', async () => {
+    const presignedUrl =
+      'https://s3.example.test/hutch-blobs/blobs/1/abc?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=sig'
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(fileService.getFile).mockResolvedValue({
+      path: 'logo.png',
+      filename: 'logo.png',
+      mime_type: 'image/png',
+      size: 4,
+      content_hash: 'cd'.repeat(32),
+      download_url: presignedUrl,
+    } as never)
+
+    const result = await callTool('hutch_get_file', { collection: 'agent-files', path: 'logo.png' })
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed).toEqual(expect.objectContaining({
+      download_url: presignedUrl,
+    }))
+    expect(parsed).not.toHaveProperty('content')
+  })
+
+  it('returns isError when the collection is not accessible (service returns null)', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(fileService.getFile).mockResolvedValue(null as never)
+
+    const result = await callTool('hutch_get_file', { collection: 'missing', path: 'x.md' })
+    expect(result.isError).toBe(true)
+  })
+
+  it('returns isError when the file is missing (404-style service error)', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(fileService.getFile).mockResolvedValue({ error: 'File not found', status: 404 } as never)
+
+    const result = await callTool('hutch_get_file', { collection: 'agent-files', path: 'nope.md' })
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toMatch(/not found/i)
+  })
+})
+
+describe('hutch_list_files', () => {
+  it('forwards the collection to fileService.listFiles and returns metadata only', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(fileService.listFiles).mockResolvedValue({
+      files: [
+        { path: 'CLAUDE.md', filename: 'CLAUDE.md', mime_type: 'text/markdown', size: 11, content_hash: 'ab'.repeat(32) },
+        { path: 'logo.png', filename: 'logo.png', mime_type: 'image/png', size: 4, content_hash: 'cd'.repeat(32) },
+      ],
+    } as never)
+
+    const result = await callTool('hutch_list_files', { collection: 'agent-files' })
+
+    expect(fileService.listFiles).toHaveBeenCalledWith('agent-files', 'user-1')
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.files).toHaveLength(2)
+    for (const file of parsed.files) {
+      expect(file).toEqual(expect.objectContaining({
+        path: expect.any(String),
+        size: expect.any(Number),
+        content_hash: expect.any(String),
+      }))
+      expect(file).not.toHaveProperty('content')
+    }
+  })
+
+  it('returns isError when the collection is not accessible', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(fileService.listFiles).mockResolvedValue(null as never)
+
+    const result = await callTool('hutch_list_files', { collection: 'missing' })
+    expect(result.isError).toBe(true)
+  })
+})

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import * as collectionService from "@/lib/services/collections";
 import * as recordService from "@/lib/services/records";
+import * as fileService from "@/lib/services/files";
 import { createView } from "@/lib/services/views";
 import { VIEW_TYPES } from "@/lib/views/types";
 
@@ -19,6 +20,8 @@ Use filter for exact/numeric/enum matches, search for free-text across string fi
 For deduplication: set unique_key via hutch_update_collection, then hutch_store_records honors on_conflict (default: replace).
 
 Views (hutch_create_view) save a table/kanban/gallery configuration on a collection so subsequent queries can reuse it.
+
+Files: hutch_put_file stores a file at a path inside a collection (auto-created with upsert-on-path), hutch_get_file reads it back, hutch_list_files lists metadata. Small UTF-8 text lives inline in the record; larger or binary content (send content_base64) goes to S3-compatible blob storage and downloads via a presigned URL — blob storage requires the HUTCH_S3_* env vars. Max file size: 4MB.
 
 This is the headless single-user Core. Multi-user sharing, organizations, invitations, and published dashboards live in Hutch Cloud (app.hutchdb.com), not here.`;
 
@@ -387,6 +390,65 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
+  server.registerTool(
+    "hutch_put_file",
+    {
+      description: "Store a file at a path inside a collection (upserts on path; the collection auto-creates if new). Small UTF-8 text is kept inline; binary or large content (use content_base64) goes to blob storage. Max 4MB. Example: use when the user says 'save this file' or the agent wants to persist a prompt, config, or image.",
+      inputSchema: {
+        collection: z.string().describe("Collection name or slug (auto-created with upsert-on-path if new)"),
+        path: z.string().describe("Relative file path within the collection (e.g. 'prompts/reviewer.md'). No '..' segments."),
+        content: z.string().optional().describe("UTF-8 text content (use this OR content_base64, not both)"),
+        content_base64: z.string().optional().describe("Base64-encoded bytes for binary content"),
+        mime_type: z.string().optional().describe("MIME type (e.g. 'text/markdown', 'image/png'). Text-like types stay inline when small."),
+      },
+      annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    async (params) => {
+      const result = await fileService.putFile(userId, organizationId, {
+        collection: params.collection,
+        path: params.path,
+        content: params.content,
+        contentBase64: params.content_base64,
+        mimeType: params.mime_type,
+      });
+      if ('error' in result) return errorResponse(result.error as string);
+      return jsonResponse(result);
+    }
+  );
+
+  server.registerTool(
+    "hutch_get_file",
+    {
+      description: "Read a file from a collection by path. Inline text files return their content; blob files return a time-limited download_url instead. Example: use when the user asks for a stored file's contents.",
+      inputSchema: {
+        collection: z.string().describe("Collection slug"),
+        path: z.string().describe("File path within the collection"),
+      },
+      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
+    },
+    async ({ collection, path }) => {
+      const result = await fileService.getFile(collection, userId, path);
+      if (!result) return collectionNotFound(collection);
+      if ('error' in result) return errorResponse(result.error as string);
+      return jsonResponse(result);
+    }
+  );
+
+  server.registerTool(
+    "hutch_list_files",
+    {
+      description: "List the files in a collection — path, filename, mime_type, size, and content_hash (no content). Example: use when the user asks 'what files are stored in agent-files?'.",
+      inputSchema: {
+        collection: z.string().describe("Collection slug"),
+      },
+      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
+    },
+    async ({ collection }) => {
+      const result = await fileService.listFiles(collection, userId);
+      if (!result) return collectionNotFound(collection);
+      return jsonResponse(result);
+    }
+  );
 
   return server;
 }

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -305,7 +305,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
       inputSchema: {
         slug: z.string().describe("Collection slug"),
         field: z.string().describe("Field name to update"),
-        type: z.enum(["text","number","boolean","date","url","email","image_url","select","multiselect","json"]).optional(),
+        type: z.enum(["text","number","boolean","date","url","email","image_url","select","multiselect","json","file"]).optional(),
         options: z.array(z.string()).optional().describe("Options for select/multiselect fields"),
         position: z.number().optional(),
         hidden: z.boolean().optional(),

--- a/src/lib/quota.test.ts
+++ b/src/lib/quota.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { beforeCreateRecord, beforeStoreFile, releaseStorage } from './quota'
+
+// Failing spec (TDD): the OSS quota seam gains two no-op file hooks. The Cloud
+// overlay replaces this module with real enforcement; Core only guarantees the
+// seam exists and resolves.
+
+describe('quota seam', () => {
+  it('keeps the existing beforeCreateRecord no-op', async () => {
+    await expect(
+      beforeCreateRecord({
+        userId: 'u1',
+        organizationId: 'o1',
+        collectionName: 'files',
+        count: 1,
+        bytes: 10,
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('exports beforeStoreFile({userId, organizationId, bytes}) as a resolving no-op', async () => {
+    expect(typeof beforeStoreFile).toBe('function')
+    await expect(
+      beforeStoreFile({ userId: 'u1', organizationId: 'o1', bytes: 1024 })
+    ).resolves.toBeUndefined()
+  })
+
+  it('exports releaseStorage({organizationId, bytes}) as a resolving no-op', async () => {
+    expect(typeof releaseStorage).toBe('function')
+    await expect(
+      releaseStorage({ organizationId: 'o1', bytes: 1024 })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/lib/quota.ts
+++ b/src/lib/quota.ts
@@ -6,7 +6,28 @@ export interface BeforeCreateRecordParams {
   bytes: number
 }
 
+export interface BeforeStoreFileParams {
+  userId: string
+  organizationId: string
+  bytes: number
+}
+
+export interface ReleaseStorageParams {
+  organizationId: string
+  bytes: number
+}
+
 // No-op in OSS. The hosted overlay (hutchdb-cloud) replaces this file with
 // a Stripe-backed quota check that throws QuotaExceeded → HTTP 402.
 export async function beforeCreateRecord(_params: BeforeCreateRecordParams): Promise<void> {
+}
+
+// No-op in OSS. The hosted overlay replaces this with a storage-quota check
+// that throws QuotaExceeded before a blob is written.
+export async function beforeStoreFile(_params: BeforeStoreFileParams): Promise<void> {
+}
+
+// No-op in OSS. The hosted overlay replaces this to credit back storage when
+// a blob is superseded or deleted.
+export async function releaseStorage(_params: ReleaseStorageParams): Promise<void> {
 }

--- a/src/lib/schema/field-types.test.ts
+++ b/src/lib/schema/field-types.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import type { FieldType } from './field-types'
+import { isSelectableField } from './field-types'
+
+// Failing spec (TDD): the FieldType union gains "file".
+//
+// NOTE: FieldType is a pure type with no runtime artifact, so the union
+// membership is a compile-time contract — the assignment below fails `tsc`
+// (and `next build`) until "file" joins the union, even though vitest's
+// runtime pass is green.
+
+describe('FieldType union', () => {
+  it('includes "file" (compile-time contract — enforced by tsc, not runtime)', () => {
+    const fileType: FieldType = 'file'
+    expect(fileType).toBe('file')
+  })
+
+  it('"file" is not a selectable field type', () => {
+    expect(isSelectableField({ type: 'file' })).toBe(false)
+  })
+})

--- a/src/lib/schema/field-types.ts
+++ b/src/lib/schema/field-types.ts
@@ -10,7 +10,8 @@ export type FieldType =
   | "image_url"
   | "select"
   | "multiselect"
-  | "json";
+  | "json"
+  | "file";
 
 export const SELECTABLE_FIELD_TYPES = ["select", "multiselect"] as const;
 export const MAX_OPTION_VALUE_LENGTH = 50;

--- a/src/lib/services/collections-files-cleanup.test.ts
+++ b/src/lib/services/collections-files-cleanup.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Failing spec (TDD): deleteCollection (src/lib/services/collections.ts) must
+// call cleanupCollectionBlobs (src/lib/services/files.ts) BEFORE hard-deleting
+// the collection row, so orphaned blobs never accumulate in storage.
+// Lives in its own file because collections.test.ts imports the real service
+// while this spec needs './files' mocked.
+// ---------------------------------------------------------------------------
+
+const { cleanupCollectionBlobs, dbDelete } = vi.hoisted(() => ({
+  cleanupCollectionBlobs: vi.fn().mockResolvedValue(undefined),
+  dbDelete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+}))
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    insert: vi.fn(() => ({ values: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) })) })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => Object.assign(Promise.resolve(undefined), { returning: vi.fn().mockResolvedValue([]) })),
+      })),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => Object.assign(Promise.resolve([]), { limit: vi.fn().mockResolvedValue([]) })),
+      })),
+    })),
+    delete: dbDelete,
+    execute: vi.fn(),
+    transaction: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/db/queries', () => ({
+  findAccessibleCollectionBySlug: vi.fn(),
+  createCollectionWithOwner: vi.fn(),
+  getCollectionRecordCount: vi.fn().mockResolvedValue(0),
+  notDeleted: { __notDeleted: true },
+}))
+
+vi.mock('@/lib/describe', () => ({
+  describeCollection: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('@/lib/revalidation', () => ({
+  revalidateDashboard: vi.fn(),
+}))
+
+vi.mock('@/lib/schema-inference', () => ({
+  inferSchema: vi.fn().mockResolvedValue({ fields: [], version: 1 }),
+  mergeSchema: vi.fn((_, b) => b),
+  isSelectableField: (f: { type: string }) => f.type === 'select' || f.type === 'multiselect',
+  MAX_OPTION_VALUE_LENGTH: 50,
+  MAX_OPTIONS_PER_FIELD: 50,
+  SELECTABLE_FIELD_TYPES: ['select', 'multiselect'],
+}))
+
+vi.mock('./views', () => ({
+  seedAutoViews: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('./files', () => ({
+  putFile: vi.fn(),
+  getFile: vi.fn(),
+  listFiles: vi.fn(),
+  deleteFile: vi.fn(),
+  cleanupCollectionBlobs,
+}))
+
+import { deleteCollection } from './collections'
+import { findAccessibleCollectionBySlug } from '@/lib/db/queries'
+
+const baseCollection = {
+  id: 1,
+  apiKeyId: 1,
+  organizationId: 'org-test',
+  name: 'Bookmarks',
+  slug: 'bookmarks',
+  uniqueKey: [],
+  schema: { fields: [], version: 1, lastInferredAt: '' },
+  description: null,
+  published: false,
+  publishedAt: null,
+  submissions: 'closed' as const,
+  visibility: 'private',
+  orgDefaultRole: 'viewer',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+const mockOrg = {
+  id: 'org-test',
+  slug: 'test',
+  name: 'Test',
+  personal: false,
+  callerRole: 'admin' as const,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  cleanupCollectionBlobs.mockResolvedValue(undefined)
+})
+
+describe('deleteCollection blob cleanup', () => {
+  it('cleans up the collection blobs before hard-deleting the collection', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({
+      organization: mockOrg, collection: baseCollection, role: 'owner',
+    } as never)
+
+    const result = await deleteCollection('bookmarks', 'user-test')
+
+    expect(result).toEqual({ deleted: true, slug: 'bookmarks' })
+    expect(cleanupCollectionBlobs).toHaveBeenCalledWith(baseCollection.id)
+    // Blob cleanup happens BEFORE the row delete (the record rows — and their
+    // blob_keys — are gone once the collection cascades away).
+    expect(cleanupCollectionBlobs.mock.invocationCallOrder[0]).toBeLessThan(
+      dbDelete.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('does not touch storage when the caller is not an owner', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue(undefined as never)
+
+    const result = await deleteCollection('bookmarks', 'user-test')
+
+    expect(result).toEqual(expect.objectContaining({ status: 404 }))
+    expect(cleanupCollectionBlobs).not.toHaveBeenCalled()
+    expect(dbDelete).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/services/collections.ts
+++ b/src/lib/services/collections.ts
@@ -10,6 +10,7 @@ import { inferSchema, mergeSchema, CollectionSchema, FieldDefinition, isSelectab
 import { FIELD_NAME_RE, MAX_FIELD_NAME_LENGTH } from "@/lib/constants";
 import { validateTrimmedLength } from "@/lib/validation";
 import { seedAutoViews } from "./views";
+import { cleanupCollectionBlobs } from "./files";
 
 export type RecentCollection = { name: string; slug: string; role: CollectionRole };
 
@@ -295,6 +296,10 @@ export async function updateCollection(slug: string, userId: string, updates: Re
 export async function deleteCollection(slug: string, userId: string) {
   const access = await findAccessibleCollectionBySlug(slug, userId, "owner");
   if (!access) return { error: "Collection not found", status: 404 };
+
+  // Reap blobs BEFORE the hard row delete — the record rows (and their
+  // blob_keys) are unrecoverable once the collection cascades away.
+  await cleanupCollectionBlobs(access.collection.id);
 
   await db.delete(collections).where(eq(collections.id, access.collection.id));
   revalidateDashboard(slug);

--- a/src/lib/services/files.test.ts
+++ b/src/lib/services/files.test.ts
@@ -1,0 +1,778 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createHash } from 'node:crypto'
+
+// ---------------------------------------------------------------------------
+// Failing spec (TDD) for src/lib/services/files.ts — files stored as records.
+//
+// A file IS a record whose `data` has the canonical shape:
+//   { path, filename, mime_type, size, content_hash, content? | blob_key? }
+//
+// Two storage tiers:
+//   INLINE — valid UTF-8, <= 262_144 bytes (MAX_INLINE_FILE_SIZE), text-like
+//            mime (text/*, application/json, or unspecified) → `content` string
+//            in the record JSON, no blob written.
+//   BLOB   — everything else, up to 4_194_304 bytes (MAX_FILE_SIZE) → written
+//            via the storage seam (src/lib/storage/seam.ts, S3-compatible),
+//            record stores `blob_key` (no `content`).
+//            Over 4MB → { error, status: 413 }.
+//            Storage seam not configured (no HUTCH_S3_* env) → the seam ops
+//            reject with a "storage not configured" error and putFile maps it
+//            to { error, status: 501 }. Inline files never touch the seam and
+//            keep working without any storage config.
+//
+// Blob downloads: getFile returns `download_url` = the presigned GET URL from
+// storage.getDownloadUrl(blob_key) (async). There is no byte-streaming path.
+// ---------------------------------------------------------------------------
+
+const MAX_INLINE_FILE_SIZE = 262_144
+const MAX_FILE_SIZE = 4_194_304
+
+const {
+  insertReturning,
+  updateReturning,
+  selectLimit,
+  rowsHolder,
+  storagePut,
+  storageDelete,
+  storageGetDownloadUrl,
+  beforeStoreFile,
+  releaseStorage,
+  createRecordsMock,
+} = vi.hoisted(() => ({
+  insertReturning: vi.fn(),
+  updateReturning: vi.fn(),
+  selectLimit: vi.fn(),
+  rowsHolder: { rows: [] as unknown[] },
+  storagePut: vi.fn(),
+  storageDelete: vi.fn(),
+  storageGetDownloadUrl: vi.fn(),
+  beforeStoreFile: vi.fn(),
+  releaseStorage: vi.fn(),
+  createRecordsMock: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({ returning: insertReturning })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => Object.assign(Promise.resolve(undefined), { returning: updateReturning })),
+      })),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() =>
+          Object.assign(Promise.resolve(rowsHolder.rows), {
+            limit: selectLimit,
+            orderBy: vi.fn(() =>
+              Object.assign(Promise.resolve(rowsHolder.rows), {
+                limit: vi.fn(() =>
+                  Object.assign(Promise.resolve(rowsHolder.rows), {
+                    offset: vi.fn(() => Promise.resolve(rowsHolder.rows)),
+                  })
+                ),
+              })
+            ),
+          })
+        ),
+      })),
+    })),
+    delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    execute: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/db/queries', () => ({
+  findCollectionByNameInOrg: vi.fn(),
+  findCollectionBySlugInOrg: vi.fn(),
+  findAccessibleCollectionBySlug: vi.fn(),
+  createCollectionWithOwner: vi.fn(),
+  getCollectionRecordCount: vi.fn().mockResolvedValue(0),
+  queryRecords: vi.fn(),
+  notDeleted: { __notDeleted: true },
+}))
+
+vi.mock('@/lib/storage/seam', () => ({
+  getStorage: vi.fn(() => ({
+    put: storagePut,
+    delete: storageDelete,
+    getDownloadUrl: storageGetDownloadUrl,
+  })),
+}))
+
+vi.mock('@/lib/quota', () => ({
+  beforeCreateRecord: vi.fn().mockResolvedValue(undefined),
+  beforeStoreFile,
+  releaseStorage,
+}))
+
+vi.mock('./records', () => ({
+  createRecords: createRecordsMock,
+}))
+
+vi.mock('@/lib/revalidation', () => ({
+  revalidateDashboard: vi.fn(),
+}))
+
+import { putFile, getFile, listFiles, deleteFile, cleanupCollectionBlobs } from './files'
+import {
+  findCollectionByNameInOrg,
+  findCollectionBySlugInOrg,
+  findAccessibleCollectionBySlug,
+  createCollectionWithOwner,
+} from '@/lib/db/queries'
+
+const sha256 = (input: string | Uint8Array) =>
+  createHash('sha256').update(input).digest('hex')
+
+const fileCollection = {
+  id: 1,
+  apiKeyId: 1,
+  organizationId: 'org-test',
+  name: 'Agent Files',
+  slug: 'agent-files',
+  uniqueKey: ['path'],
+  schema: { fields: [], version: 1, lastInferredAt: new Date().toISOString() },
+  description: null,
+  published: false,
+  publishedAt: null,
+  submissions: 'closed' as const,
+  visibility: 'private',
+  orgDefaultRole: 'viewer',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+const mockOrg = {
+  id: 'org-test',
+  slug: 'test',
+  name: 'Test',
+  personal: false,
+  callerRole: 'admin' as const,
+}
+
+function putParams(overrides: Record<string, unknown> = {}) {
+  return {
+    collection: 'agent-files',
+    path: 'CLAUDE.md',
+    content: 'hello world',
+    mimeType: 'text/markdown',
+    ...overrides,
+  }
+}
+
+// The `data` object handed to createRecords for the last putFile call.
+function lastCreateRecordsData(): Record<string, unknown> {
+  const call = createRecordsMock.mock.calls.at(-1)
+  expect(call, 'expected createRecords to have been called').toBeDefined()
+  const params = call![2] as { data?: Record<string, unknown> }
+  expect(params.data, 'expected createRecords to receive a single data object').toBeDefined()
+  return params.data!
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  rowsHolder.rows = []
+  selectLimit.mockResolvedValue([])
+  storagePut.mockResolvedValue(undefined)
+  storageDelete.mockResolvedValue(undefined)
+  storageGetDownloadUrl.mockResolvedValue(
+    'https://s3.example.test/hutch-blobs/blobs/1/abc?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=sig'
+  )
+  beforeStoreFile.mockResolvedValue(undefined)
+  releaseStorage.mockResolvedValue(undefined)
+  vi.mocked(findCollectionByNameInOrg).mockResolvedValue(fileCollection as never)
+  vi.mocked(findCollectionBySlugInOrg).mockResolvedValue(fileCollection as never)
+  createRecordsMock.mockResolvedValue({
+    collection: { name: 'Agent Files', slug: 'agent-files' },
+    action: 'created',
+    record: { id: 1 },
+  })
+})
+
+describe('putFile — input validation', () => {
+  it('returns 400 when neither content nor contentBase64 is provided', async () => {
+    const result = await putFile('user-test', 'org-test', {
+      collection: 'agent-files',
+      path: 'CLAUDE.md',
+    })
+    expect(result).toEqual(expect.objectContaining({ status: 400 }))
+    expect(createRecordsMock).not.toHaveBeenCalled()
+    expect(storagePut).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when both content and contentBase64 are provided', async () => {
+    const result = await putFile('user-test', 'org-test', putParams({
+      contentBase64: Buffer.from('hello').toString('base64'),
+    }))
+    expect(result).toEqual(expect.objectContaining({ status: 400 }))
+    expect(createRecordsMock).not.toHaveBeenCalled()
+  })
+
+  describe('path validation (400, nothing persisted)', () => {
+    const badPaths: [string, string][] = [
+      ['empty path', ''],
+      ['absolute path', '/etc/passwd'],
+      ['leading .. segment', '../secrets.md'],
+      ['embedded .. segment', 'prompts/../../escape.md'],
+      ['trailing .. segment', 'prompts/..'],
+      ['bare ..', '..'],
+      ['null byte', 'evil\0.md'],
+      ['longer than 512 chars', 'a'.repeat(513)],
+    ]
+
+    for (const [label, path] of badPaths) {
+      it(`rejects ${label}`, async () => {
+        const result = await putFile('user-test', 'org-test', putParams({ path }))
+        expect(result).toEqual(expect.objectContaining({ status: 400 }))
+        expect(createRecordsMock).not.toHaveBeenCalled()
+        expect(storagePut).not.toHaveBeenCalled()
+      })
+    }
+
+    it('accepts a path of exactly 512 chars', async () => {
+      const result = await putFile('user-test', 'org-test', putParams({ path: 'a'.repeat(512) }))
+      expect(result).not.toEqual(expect.objectContaining({ status: 400 }))
+      expect(createRecordsMock).toHaveBeenCalled()
+    })
+  })
+
+  it('returns 413 when string content exceeds MAX_FILE_SIZE (4MB)', async () => {
+    const result = await putFile('user-test', 'org-test', putParams({
+      content: 'a'.repeat(MAX_FILE_SIZE + 1),
+      mimeType: 'text/plain',
+    }))
+    expect(result).toEqual(expect.objectContaining({ status: 413 }))
+    expect(storagePut).not.toHaveBeenCalled()
+    expect(createRecordsMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 413 when base64 content decodes to more than 4MB', async () => {
+    const result = await putFile('user-test', 'org-test', putParams({
+      content: undefined,
+      contentBase64: Buffer.alloc(MAX_FILE_SIZE + 1).toString('base64'),
+      mimeType: 'application/octet-stream',
+    }))
+    expect(result).toEqual(expect.objectContaining({ status: 413 }))
+    expect(storagePut).not.toHaveBeenCalled()
+    expect(createRecordsMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('putFile — inline tier', () => {
+  it('stores small UTF-8 text with a text/* mime inline (content in record, no blob)', async () => {
+    await putFile('user-test', 'org-test', putParams())
+
+    expect(createRecordsMock).toHaveBeenCalledWith('user-test', 'org-test', expect.objectContaining({
+      collection: 'agent-files',
+      on_conflict: 'replace',
+    }))
+    const data = lastCreateRecordsData()
+    expect(data).toEqual(expect.objectContaining({
+      path: 'CLAUDE.md',
+      filename: 'CLAUDE.md',
+      mime_type: 'text/markdown',
+      size: Buffer.byteLength('hello world'),
+      content_hash: sha256('hello world'),
+      content: 'hello world',
+    }))
+    expect(data).not.toHaveProperty('blob_key')
+    expect(storagePut).not.toHaveBeenCalled()
+  })
+
+  it('treats application/json as text-like (inline)', async () => {
+    await putFile('user-test', 'org-test', putParams({
+      path: 'config.json',
+      content: '{"a":1}',
+      mimeType: 'application/json',
+    }))
+    const data = lastCreateRecordsData()
+    expect(data.content).toBe('{"a":1}')
+    expect(data).not.toHaveProperty('blob_key')
+    expect(storagePut).not.toHaveBeenCalled()
+  })
+
+  it('treats unspecified mime with UTF-8 content as text-like (inline)', async () => {
+    await putFile('user-test', 'org-test', {
+      collection: 'agent-files',
+      path: 'notes.txt',
+      content: 'plain notes',
+    })
+    const data = lastCreateRecordsData()
+    expect(data.content).toBe('plain notes')
+    expect(data).not.toHaveProperty('blob_key')
+    expect(storagePut).not.toHaveBeenCalled()
+  })
+
+  it('derives filename as the basename of a nested path', async () => {
+    await putFile('user-test', 'org-test', putParams({ path: 'prompts/reviewer.md' }))
+    const data = lastCreateRecordsData()
+    expect(data.path).toBe('prompts/reviewer.md')
+    expect(data.filename).toBe('reviewer.md')
+  })
+
+  it('computes size as UTF-8 byte length, not character count', async () => {
+    await putFile('user-test', 'org-test', putParams({ content: 'héllo' }))
+    const data = lastCreateRecordsData()
+    expect(data.size).toBe(6) // 'héllo' is 5 chars, 6 bytes
+    expect(data.content_hash).toBe(sha256(Buffer.from('héllo', 'utf8')))
+  })
+
+  it('keeps content exactly at MAX_INLINE_FILE_SIZE (256KB) inline', async () => {
+    await putFile('user-test', 'org-test', putParams({
+      content: 'a'.repeat(MAX_INLINE_FILE_SIZE),
+      mimeType: 'text/plain',
+    }))
+    const data = lastCreateRecordsData()
+    expect(data.content).toBeDefined()
+    expect(data).not.toHaveProperty('blob_key')
+    expect(storagePut).not.toHaveBeenCalled()
+  })
+})
+
+describe('putFile — blob tier', () => {
+  const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+  const pngBase64 = Buffer.from(pngBytes).toString('base64')
+
+  it('routes binary base64 content to the storage driver and stores blob_key', async () => {
+    await putFile('user-test', 'org-test', {
+      collection: 'agent-files',
+      path: 'logo.png',
+      contentBase64: pngBase64,
+      mimeType: 'image/png',
+    })
+
+    expect(storagePut).toHaveBeenCalledTimes(1)
+    const [key, bytes, contentType] = storagePut.mock.calls[0]
+    expect(typeof key).toBe('string')
+    expect(Buffer.from(bytes as Uint8Array).equals(Buffer.from(pngBytes))).toBe(true)
+    expect(contentType).toBe('image/png')
+
+    const data = lastCreateRecordsData()
+    expect(data).toEqual(expect.objectContaining({
+      path: 'logo.png',
+      filename: 'logo.png',
+      mime_type: 'image/png',
+      size: pngBytes.length,
+      content_hash: sha256(pngBytes),
+      blob_key: key,
+    }))
+    expect(data).not.toHaveProperty('content')
+  })
+
+  it('routes text over MAX_INLINE_FILE_SIZE to the blob tier even when UTF-8', async () => {
+    const big = 'a'.repeat(MAX_INLINE_FILE_SIZE + 1)
+    await putFile('user-test', 'org-test', putParams({ content: big, mimeType: 'text/plain' }))
+
+    expect(storagePut).toHaveBeenCalledTimes(1)
+    const data = lastCreateRecordsData()
+    expect(data.blob_key).toBeDefined()
+    expect(data).not.toHaveProperty('content')
+  })
+
+  it('routes small UTF-8 content with a non-text mime to the blob tier', async () => {
+    await putFile('user-test', 'org-test', putParams({
+      path: 'anim.gif',
+      content: 'GIF89a',
+      mimeType: 'image/gif',
+    }))
+    expect(storagePut).toHaveBeenCalledTimes(1)
+    const data = lastCreateRecordsData()
+    expect(data.blob_key).toBeDefined()
+    expect(data).not.toHaveProperty('content')
+  })
+
+  it('accepts a blob of exactly MAX_FILE_SIZE (4MB)', async () => {
+    const result = await putFile('user-test', 'org-test', putParams({
+      content: 'a'.repeat(MAX_FILE_SIZE),
+      mimeType: 'text/plain',
+    }))
+    expect(result).not.toEqual(expect.objectContaining({ status: 413 }))
+    expect(storagePut).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls the beforeStoreFile quota seam before writing the blob', async () => {
+    await putFile('user-test', 'org-test', {
+      collection: 'agent-files',
+      path: 'logo.png',
+      contentBase64: pngBase64,
+      mimeType: 'image/png',
+    })
+
+    expect(beforeStoreFile).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user-test',
+      organizationId: 'org-test',
+      bytes: pngBytes.length,
+    }))
+    expect(beforeStoreFile.mock.invocationCallOrder[0]).toBeLessThan(
+      storagePut.mock.invocationCallOrder[0]
+    )
+  })
+})
+
+describe('putFile — storage not configured (no HUTCH_S3_* env)', () => {
+  // The seam is the source of truth: its ops reject when the env is absent.
+  const notConfigured = new Error(
+    'Blob storage is not configured. Set the HUTCH_S3_* environment variables.'
+  )
+
+  beforeEach(() => {
+    storagePut.mockRejectedValue(notConfigured)
+    storageDelete.mockRejectedValue(notConfigured)
+    storageGetDownloadUrl.mockRejectedValue(notConfigured)
+  })
+
+  it('blob-tier putFile returns a clear 501 error and persists nothing', async () => {
+    const result = await putFile('user-test', 'org-test', {
+      collection: 'agent-files',
+      path: 'logo.png',
+      contentBase64: Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'),
+      mimeType: 'image/png',
+    })
+
+    expect(result).toEqual(expect.objectContaining({ status: 501 }))
+    expect((result as { error: string }).error).toMatch(/not configured/i)
+    expect(createRecordsMock).not.toHaveBeenCalled()
+  })
+
+  it('inline putFile still succeeds without any storage config', async () => {
+    const result = await putFile('user-test', 'org-test', putParams())
+
+    expect(result).toEqual(expect.objectContaining({
+      path: 'CLAUDE.md',
+      content_hash: sha256('hello world'),
+    }))
+    expect(storagePut).not.toHaveBeenCalled()
+    expect(createRecordsMock).toHaveBeenCalled()
+  })
+})
+
+describe('putFile — collection auto-create', () => {
+  it('auto-creates a missing collection with uniqueKey ["path"] and a file-typed schema field', async () => {
+    vi.mocked(findCollectionByNameInOrg).mockResolvedValue(undefined as never)
+    vi.mocked(findCollectionBySlugInOrg).mockResolvedValue(undefined as never)
+    vi.mocked(createCollectionWithOwner).mockResolvedValue({
+      ...fileCollection,
+      name: 'Prompts',
+      slug: 'prompts-aaaaaaaa',
+    } as never)
+
+    await putFile('user-test', 'org-test', putParams({ collection: 'prompts' }))
+
+    expect(createCollectionWithOwner).toHaveBeenCalledWith(expect.objectContaining({
+      organizationId: 'org-test',
+      ownerUserId: 'user-test',
+      uniqueKey: ['path'],
+    }))
+    const call = vi.mocked(createCollectionWithOwner).mock.calls[0][0] as {
+      schema?: { fields: { type: string }[] }
+    }
+    expect(call.schema?.fields).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'file' })])
+    )
+  })
+
+  it('does not create a collection when one already exists', async () => {
+    await putFile('user-test', 'org-test', putParams())
+    expect(createCollectionWithOwner).not.toHaveBeenCalled()
+  })
+})
+
+describe('putFile — last-write-wins replace and blob supersede', () => {
+  const oldBlobRecord = {
+    id: 7,
+    collectionId: 1,
+    data: {
+      path: 'CLAUDE.md',
+      filename: 'CLAUDE.md',
+      mime_type: 'application/octet-stream',
+      size: 1024,
+      content_hash: 'deadbeef'.repeat(8),
+      blob_key: 'blobs/1/old-key',
+    },
+    deletedAt: null,
+  }
+
+  it('deletes the superseded blob and releases storage when content_hash changes', async () => {
+    selectLimit.mockResolvedValue([oldBlobRecord])
+    rowsHolder.rows = [oldBlobRecord]
+
+    await putFile('user-test', 'org-test', putParams({ content: 'brand new content' }))
+
+    expect(storageDelete).toHaveBeenCalledWith(['blobs/1/old-key'])
+    expect(releaseStorage).toHaveBeenCalledWith(expect.objectContaining({
+      organizationId: 'org-test',
+      bytes: 1024,
+    }))
+  })
+
+  it('does not delete the blob or release storage when content_hash is unchanged', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4])
+    const existing = {
+      ...oldBlobRecord,
+      data: {
+        ...oldBlobRecord.data,
+        size: bytes.length,
+        content_hash: sha256(bytes),
+        mime_type: 'application/octet-stream',
+      },
+    }
+    selectLimit.mockResolvedValue([existing])
+    rowsHolder.rows = [existing]
+
+    await putFile('user-test', 'org-test', {
+      collection: 'agent-files',
+      path: 'CLAUDE.md',
+      contentBase64: Buffer.from(bytes).toString('base64'),
+      mimeType: 'application/octet-stream',
+    })
+
+    expect(storageDelete).not.toHaveBeenCalled()
+    expect(releaseStorage).not.toHaveBeenCalled()
+  })
+
+  it('does not touch storage when the replaced record was inline', async () => {
+    const inlineRecord = {
+      id: 8,
+      collectionId: 1,
+      data: {
+        path: 'CLAUDE.md',
+        filename: 'CLAUDE.md',
+        mime_type: 'text/markdown',
+        size: 3,
+        content_hash: sha256('old'),
+        content: 'old',
+      },
+      deletedAt: null,
+    }
+    selectLimit.mockResolvedValue([inlineRecord])
+    rowsHolder.rows = [inlineRecord]
+
+    await putFile('user-test', 'org-test', putParams({ content: 'new' }))
+
+    expect(storageDelete).not.toHaveBeenCalled()
+    expect(releaseStorage).not.toHaveBeenCalled()
+  })
+})
+
+describe('putFile — return value', () => {
+  it('returns file metadata and never echoes the content', async () => {
+    const result = await putFile('user-test', 'org-test', putParams())
+
+    expect(result).toEqual(expect.objectContaining({
+      path: 'CLAUDE.md',
+      size: Buffer.byteLength('hello world'),
+      mime_type: 'text/markdown',
+      content_hash: sha256('hello world'),
+    }))
+    expect(result).not.toHaveProperty('content')
+  })
+})
+
+describe('getFile', () => {
+  const inlineRecord = {
+    id: 10,
+    collectionId: 1,
+    data: {
+      path: 'CLAUDE.md',
+      filename: 'CLAUDE.md',
+      mime_type: 'text/markdown',
+      size: 11,
+      content_hash: sha256('hello world'),
+      content: 'hello world',
+    },
+    deletedAt: null,
+  }
+
+  const blobRecord = {
+    id: 11,
+    collectionId: 1,
+    data: {
+      path: 'prompts/reviewer.md',
+      filename: 'reviewer.md',
+      mime_type: 'image/png',
+      size: 8,
+      content_hash: 'ab'.repeat(32),
+      blob_key: 'blobs/1/abc',
+    },
+    deletedAt: null,
+  }
+
+  it('returns null when the caller has no access to the collection', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue(undefined as never)
+    const result = await getFile('agent-files', 'user-test', 'CLAUDE.md')
+    expect(result).toBeNull()
+  })
+
+  it('returns a 404-style error when no active file record matches the path', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({
+      organization: mockOrg, collection: fileCollection, role: 'viewer',
+    } as never)
+    selectLimit.mockResolvedValue([])
+    rowsHolder.rows = []
+
+    const result = await getFile('agent-files', 'user-test', 'missing.md')
+    expect(result).toEqual(expect.objectContaining({ status: 404 }))
+  })
+
+  it('returns metadata plus content for an inline file', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({
+      organization: mockOrg, collection: fileCollection, role: 'viewer',
+    } as never)
+    selectLimit.mockResolvedValue([inlineRecord])
+    rowsHolder.rows = [inlineRecord]
+
+    const result = await getFile('agent-files', 'user-test', 'CLAUDE.md')
+    expect(result).toEqual(expect.objectContaining({
+      path: 'CLAUDE.md',
+      filename: 'CLAUDE.md',
+      mime_type: 'text/markdown',
+      size: 11,
+      content: 'hello world',
+    }))
+    expect((result as Record<string, unknown>).download_url).toBeUndefined()
+  })
+
+  it('returns metadata plus the presigned download_url (no content) for a blob file', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({
+      organization: mockOrg, collection: fileCollection, role: 'viewer',
+    } as never)
+    selectLimit.mockResolvedValue([blobRecord])
+    rowsHolder.rows = [blobRecord]
+    const presigned =
+      'https://s3.example.test/hutch-blobs/blobs/1/abc?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=sig'
+    storageGetDownloadUrl.mockResolvedValue(presigned)
+
+    const result = await getFile('agent-files', 'user-test', 'prompts/reviewer.md')
+    expect(storageGetDownloadUrl).toHaveBeenCalledWith('blobs/1/abc')
+    expect(result).toEqual(expect.objectContaining({
+      path: 'prompts/reviewer.md',
+      mime_type: 'image/png',
+      download_url: presigned,
+    }))
+    expect(result).not.toHaveProperty('content')
+  })
+})
+
+describe('listFiles', () => {
+  it('returns null when the caller has no access', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue(undefined as never)
+    const result = await listFiles('agent-files', 'user-test')
+    expect(result).toBeNull()
+  })
+
+  it('returns metadata for active file records only, with no content field', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({
+      organization: mockOrg, collection: fileCollection, role: 'viewer',
+    } as never)
+    const rows = [
+      {
+        id: 1,
+        collectionId: 1,
+        data: {
+          path: 'CLAUDE.md', filename: 'CLAUDE.md', mime_type: 'text/markdown',
+          size: 11, content_hash: sha256('hello world'), content: 'hello world',
+        },
+        deletedAt: null,
+      },
+      {
+        id: 2,
+        collectionId: 1,
+        data: {
+          path: 'logo.png', filename: 'logo.png', mime_type: 'image/png',
+          size: 8, content_hash: 'ab'.repeat(32), blob_key: 'blobs/1/abc',
+        },
+        deletedAt: null,
+      },
+    ]
+    rowsHolder.rows = rows
+    selectLimit.mockResolvedValue(rows)
+
+    const result = await listFiles('agent-files', 'user-test')
+    expect(result).toEqual(expect.objectContaining({
+      files: expect.arrayContaining([
+        expect.objectContaining({ path: 'CLAUDE.md', mime_type: 'text/markdown', size: 11 }),
+        expect.objectContaining({ path: 'logo.png', mime_type: 'image/png', size: 8 }),
+      ]),
+    }))
+    const files = (result as { files: Record<string, unknown>[] }).files
+    expect(files).toHaveLength(2)
+    for (const file of files) {
+      expect(file).not.toHaveProperty('content')
+    }
+  })
+})
+
+describe('deleteFile', () => {
+  it('returns null when the caller has no editor access', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue(undefined as never)
+    const result = await deleteFile('agent-files', 'user-test', 'CLAUDE.md')
+    expect(result).toBeNull()
+  })
+
+  it('returns a 404-style error when no active file record matches the path', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({
+      organization: mockOrg, collection: fileCollection, role: 'editor',
+    } as never)
+    selectLimit.mockResolvedValue([])
+    rowsHolder.rows = []
+
+    const result = await deleteFile('agent-files', 'user-test', 'missing.md')
+    expect(result).toEqual(expect.objectContaining({ status: 404 }))
+  })
+
+  it('soft-deletes the record and RETAINS the blob (restorable)', async () => {
+    const blobRecord = {
+      id: 11,
+      collectionId: 1,
+      data: {
+        path: 'logo.png', filename: 'logo.png', mime_type: 'image/png',
+        size: 8, content_hash: 'ab'.repeat(32), blob_key: 'blobs/1/abc',
+      },
+      deletedAt: null,
+    }
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({
+      organization: mockOrg, collection: fileCollection, role: 'editor',
+    } as never)
+    selectLimit.mockResolvedValue([blobRecord])
+    rowsHolder.rows = [blobRecord]
+
+    const result = await deleteFile('agent-files', 'user-test', 'logo.png')
+
+    expect(result).toEqual(expect.objectContaining({ deleted: true, path: 'logo.png' }))
+    const { db } = await import('@/lib/db')
+    expect(vi.mocked(db.update)).toHaveBeenCalled() // soft delete via deletedAt
+    expect(vi.mocked(db.delete)).not.toHaveBeenCalled() // no hard delete
+    expect(storageDelete).not.toHaveBeenCalled() // blob retained
+    expect(releaseStorage).not.toHaveBeenCalled()
+  })
+})
+
+describe('cleanupCollectionBlobs', () => {
+  it('deletes the blobs of ALL records including soft-deleted ones', async () => {
+    rowsHolder.rows = [
+      { id: 1, collectionId: 1, data: { path: 'a.png', blob_key: 'blobs/1/a' }, deletedAt: null },
+      { id: 2, collectionId: 1, data: { path: 'b.md', content: 'inline only' }, deletedAt: null },
+      { id: 3, collectionId: 1, data: { path: 'c.png', blob_key: 'blobs/1/c' }, deletedAt: new Date() },
+    ]
+
+    await cleanupCollectionBlobs(1)
+
+    expect(storageDelete).toHaveBeenCalledTimes(1)
+    const keys = storageDelete.mock.calls[0][0] as string[]
+    expect(keys).toEqual(expect.arrayContaining(['blobs/1/a', 'blobs/1/c']))
+    expect(keys).toHaveLength(2)
+  })
+
+  it('does not call the storage driver when the collection has no blobs', async () => {
+    rowsHolder.rows = [
+      { id: 1, collectionId: 1, data: { path: 'b.md', content: 'inline only' }, deletedAt: null },
+    ]
+
+    await cleanupCollectionBlobs(1)
+
+    expect(storageDelete).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/services/files.ts
+++ b/src/lib/services/files.ts
@@ -1,0 +1,294 @@
+import { createHash } from "node:crypto";
+import { nanoid } from "nanoid";
+import { db } from "@/lib/db";
+import { records } from "@/lib/db/schema";
+import { findCollectionByNameInOrg, findCollectionBySlugInOrg, findAccessibleCollectionBySlug, createCollectionWithOwner, notDeleted } from "@/lib/db/queries";
+import { eq, and, sql } from "drizzle-orm";
+import { getStorage } from "@/lib/storage/seam";
+import { beforeStoreFile, releaseStorage } from "@/lib/quota";
+import { createRecords } from "./records";
+import { revalidateDashboard } from "@/lib/revalidation";
+import { slugify, uniqueSlug, titleCase } from "@/lib/slugify";
+import { MAX_INLINE_FILE_SIZE, MAX_FILE_SIZE } from "@/lib/constants";
+import type { CollectionSchema } from "@/lib/schema-inference";
+
+// Files stored as records. A file IS a record whose `data` has the canonical
+// shape { path, filename, mime_type, size, content_hash, content? | blob_key? }.
+//
+// Two storage tiers:
+//   INLINE — valid UTF-8, <= MAX_INLINE_FILE_SIZE, text-like mime → `content`
+//            string inside the record JSON. Works without any storage config.
+//   BLOB   — everything else, up to MAX_FILE_SIZE → bytes go through the
+//            storage seam (src/lib/storage/seam.ts); the record stores
+//            `blob_key`. Requires the HUTCH_S3_* env (else 501).
+
+const MAX_PATH_LENGTH = 512;
+
+type FileData = {
+  path: string;
+  filename: string;
+  mime_type: string;
+  size: number;
+  content_hash: string;
+  content?: string;
+  blob_key?: string;
+};
+
+type FileMetadata = Omit<FileData, "content" | "blob_key">;
+
+export type PutFileParams = {
+  collection: string;
+  path: string;
+  content?: string;
+  contentBase64?: string;
+  mimeType?: string;
+};
+
+function isValidPath(path: string): boolean {
+  if (!path || path.length > MAX_PATH_LENGTH) return false;
+  if (path.startsWith("/") || path.includes("\0")) return false;
+  if (path.split("/").some((segment) => segment === "..")) return false;
+  return true;
+}
+
+function isTextLikeMime(mimeType: string | undefined): boolean {
+  if (!mimeType) return true;
+  return mimeType.startsWith("text/") || mimeType === "application/json";
+}
+
+function isValidUtf8(bytes: Uint8Array): boolean {
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function toMetadata(data: FileData): FileMetadata {
+  return {
+    path: data.path,
+    filename: data.filename,
+    mime_type: data.mime_type,
+    size: data.size,
+    content_hash: data.content_hash,
+  };
+}
+
+// Preset schema for auto-created file collections — records upsert on path.
+function fileCollectionSchema(): CollectionSchema {
+  return {
+    fields: [
+      { name: "path", type: "text", inferred: false, position: 0, hidden: false },
+      { name: "filename", type: "text", inferred: false, position: 1, hidden: false },
+      { name: "mime_type", type: "text", inferred: false, position: 2, hidden: false },
+      { name: "size", type: "number", inferred: false, position: 3, hidden: false },
+      { name: "content_hash", type: "text", inferred: false, position: 4, hidden: true },
+      { name: "content", type: "file", inferred: false, position: 5, hidden: false },
+    ],
+    version: 1,
+    lastInferredAt: new Date().toISOString(),
+  };
+}
+
+async function findFileRecord(collectionId: number, path: string) {
+  const [existing] = await db
+    .select()
+    .from(records)
+    .where(
+      and(
+        eq(records.collectionId, collectionId),
+        sql`${records.data} @> ${JSON.stringify({ path })}::jsonb`,
+        notDeleted
+      )
+    )
+    .limit(1);
+  return existing;
+}
+
+export async function putFile(userId: string, organizationId: string, params: PutFileParams) {
+  const { collection: collectionName, path, content, contentBase64, mimeType } = params;
+
+  if ((content === undefined) === (contentBase64 === undefined)) {
+    return { error: "Provide exactly one of 'content' or 'content_base64'", status: 400 };
+  }
+
+  if (typeof path !== "string" || !isValidPath(path)) {
+    return { error: "Invalid path: must be a relative path without '..' segments, under 513 characters", status: 400 };
+  }
+
+  const bytes: Uint8Array =
+    content !== undefined
+      ? new Uint8Array(Buffer.from(content, "utf8"))
+      : new Uint8Array(Buffer.from(contentBase64!, "base64"));
+  const size = bytes.byteLength;
+
+  if (size > MAX_FILE_SIZE) {
+    return { error: "File exceeds the 4MB size limit", status: 413 };
+  }
+
+  const inline =
+    size <= MAX_INLINE_FILE_SIZE && isTextLikeMime(mimeType) && (content !== undefined || isValidUtf8(bytes));
+
+  const contentHash = createHash("sha256").update(bytes).digest("hex");
+  const filename = path.split("/").pop()!;
+  const mime = mimeType ?? (inline ? "text/plain" : "application/octet-stream");
+
+  // Find or create the collection within the caller's org (mirrors createRecords).
+  let collection = await findCollectionByNameInOrg(collectionName, organizationId);
+  if (!collection) {
+    collection = await findCollectionBySlugInOrg(slugify(collectionName), organizationId);
+  }
+  if (!collection) {
+    collection = await createCollectionWithOwner({
+      organizationId,
+      ownerUserId: userId,
+      name: titleCase(collectionName),
+      slug: uniqueSlug(collectionName),
+      uniqueKey: ["path"],
+      schema: fileCollectionSchema(),
+    });
+  }
+
+  // Snapshot the record being replaced (if any) so a superseded blob can be
+  // cleaned up after the new version lands.
+  const existing = await findFileRecord(collection.id, path);
+  const existingData = existing?.data as FileData | undefined;
+
+  const data: FileData = { path, filename, mime_type: mime, size, content_hash: contentHash };
+  let newBlobKey: string | undefined;
+
+  if (inline) {
+    data.content = content !== undefined ? content : new TextDecoder("utf-8").decode(bytes);
+  } else if (existingData?.blob_key && existingData.content_hash === contentHash) {
+    // Same bytes already stored — reuse the blob, no rewrite, quota-neutral.
+    data.blob_key = existingData.blob_key;
+  } else {
+    await beforeStoreFile({ userId, organizationId, bytes: size });
+    newBlobKey = `blobs/${collection.id}/${nanoid()}`;
+    try {
+      await getStorage().put(newBlobKey, bytes, mime);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Blob storage write failed";
+      if (/not configured/i.test(message)) {
+        return { error: message, status: 501 };
+      }
+      return { error: "Failed to write file to blob storage", status: 502 };
+    }
+    data.blob_key = newBlobKey;
+  }
+
+  const result = await createRecords(userId, organizationId, {
+    collection: collection.slug,
+    data: data as unknown as Record<string, unknown>,
+    on_conflict: "replace",
+  });
+  if (result && typeof result === "object" && "error" in result) {
+    // The record write failed after a fresh blob landed — reap it and credit
+    // the quota back so a rejected write can't leak storage.
+    if (newBlobKey) {
+      try {
+        await getStorage().delete([newBlobKey]);
+        await releaseStorage({ organizationId, bytes: size });
+      } catch (err) {
+        console.error("Failed to reap blob after record-write failure", newBlobKey, err);
+      }
+    }
+    return result;
+  }
+
+  // The replaced version pointed at a different blob — delete it and credit
+  // the storage back. Best-effort: an orphaned blob must not fail the write.
+  if (existingData?.blob_key && existingData.content_hash !== contentHash) {
+    try {
+      await getStorage().delete([existingData.blob_key]);
+      await releaseStorage({ organizationId, bytes: existingData.size });
+    } catch (err) {
+      console.error("Failed to delete superseded blob", existingData.blob_key, err);
+    }
+  }
+
+  return toMetadata(data);
+}
+
+export async function getFile(slug: string, userId: string, path: string) {
+  const access = await findAccessibleCollectionBySlug(slug, userId, "viewer");
+  if (!access) return null;
+
+  const record = await findFileRecord(access.collection.id, path);
+  if (!record) return { error: "File not found", status: 404 };
+
+  const data = record.data as FileData;
+  if (data.content !== undefined) {
+    return { ...toMetadata(data), content: data.content };
+  }
+
+  let downloadUrl: string;
+  try {
+    downloadUrl = await getStorage().getDownloadUrl(data.blob_key!);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Blob storage read failed";
+    if (/not configured/i.test(message)) {
+      return { error: message, status: 501 };
+    }
+    return { error: "Failed to resolve file download URL", status: 502 };
+  }
+  return { ...toMetadata(data), download_url: downloadUrl };
+}
+
+export async function listFiles(slug: string, userId: string) {
+  const access = await findAccessibleCollectionBySlug(slug, userId, "viewer");
+  if (!access) return null;
+
+  const rows = await db
+    .select()
+    .from(records)
+    .where(and(eq(records.collectionId, access.collection.id), notDeleted));
+
+  const files = rows
+    .map((row) => row.data as FileData)
+    .filter((data) => data && typeof data.path === "string")
+    .map(toMetadata)
+    .sort((a, b) => a.path.localeCompare(b.path));
+
+  return { files };
+}
+
+export async function deleteFile(slug: string, userId: string, path: string) {
+  const access = await findAccessibleCollectionBySlug(slug, userId, "editor");
+  if (!access) return null;
+
+  const record = await findFileRecord(access.collection.id, path);
+  if (!record) return { error: "File not found", status: 404 };
+
+  // Soft delete only — the blob is RETAINED so the record stays restorable.
+  // Blobs are reaped when the whole collection dies (cleanupCollectionBlobs).
+  await db.update(records).set({ deletedAt: new Date() }).where(eq(records.id, record.id));
+  revalidateDashboard(slug);
+  return { deleted: true, path };
+}
+
+/**
+ * Delete every blob belonging to a collection — including blobs referenced by
+ * soft-deleted records. Called by deleteCollection BEFORE the hard row delete,
+ * because the record rows (and their blob_keys) are gone once the collection
+ * cascades away. Best-effort: storage failures must not block the delete.
+ */
+export async function cleanupCollectionBlobs(collectionId: number): Promise<void> {
+  const rows = await db
+    .select()
+    .from(records)
+    .where(eq(records.collectionId, collectionId));
+
+  const keys = rows
+    .map((row) => (row.data as FileData | null)?.blob_key)
+    .filter((key): key is string => typeof key === "string");
+
+  if (keys.length === 0) return;
+
+  try {
+    await getStorage().delete(keys);
+  } catch (err) {
+    console.error(`Failed to clean up ${keys.length} blob(s) for collection ${collectionId}`, err);
+  }
+}

--- a/src/lib/services/files.ts
+++ b/src/lib/services/files.ts
@@ -46,9 +46,22 @@ export type PutFileParams = {
 
 function isValidPath(path: string): boolean {
   if (!path || path.length > MAX_PATH_LENGTH) return false;
-  if (path.startsWith("/") || path.includes("\0")) return false;
-  if (path.split("/").some((segment) => segment === "..")) return false;
+  if (path.startsWith("/") || path.endsWith("/") || path.includes("\0")) return false;
+  if (path.split("/").some((segment) => segment === ".." || segment === "." || segment === "")) return false;
   return true;
+}
+
+// A record's blob_key is only trusted when it points inside this collection's
+// own prefix — record data is writable via hutch_store_records, so a forged
+// key must never reach a presign or delete.
+function ownsBlobKey(collectionId: number, key: string | undefined): key is string {
+  return typeof key === "string" && key.startsWith(`blobs/${collectionId}/`);
+}
+
+// The seam mock in tests rejects with a plain Error, so unconfigured storage
+// is detected by message, not instanceof.
+function isStorageNotConfigured(err: unknown): err is Error {
+  return err instanceof Error && /not configured/i.test(err.message);
 }
 
 function isTextLikeMime(mimeType: string | undefined): boolean {
@@ -56,12 +69,11 @@ function isTextLikeMime(mimeType: string | undefined): boolean {
   return mimeType.startsWith("text/") || mimeType === "application/json";
 }
 
-function isValidUtf8(bytes: Uint8Array): boolean {
+function decodeUtf8(bytes: Uint8Array): string | null {
   try {
-    new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-    return true;
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -114,7 +126,12 @@ export async function putFile(userId: string, organizationId: string, params: Pu
   }
 
   if (typeof path !== "string" || !isValidPath(path)) {
-    return { error: "Invalid path: must be a relative path without '..' segments, under 513 characters", status: 400 };
+    return { error: "Invalid path: must be a relative path without '.' or '..' segments, 512 characters or fewer", status: 400 };
+  }
+
+  // Reject oversized base64 by string length before paying for the decode.
+  if (contentBase64 !== undefined && contentBase64.length > Math.ceil(MAX_FILE_SIZE / 3) * 4 + 4) {
+    return { error: "File exceeds the 4MB size limit", status: 413 };
   }
 
   const bytes: Uint8Array =
@@ -127,8 +144,13 @@ export async function putFile(userId: string, organizationId: string, params: Pu
     return { error: "File exceeds the 4MB size limit", status: 413 };
   }
 
-  const inline =
-    size <= MAX_INLINE_FILE_SIZE && isTextLikeMime(mimeType) && (content !== undefined || isValidUtf8(bytes));
+  const decodedText =
+    size <= MAX_INLINE_FILE_SIZE && isTextLikeMime(mimeType)
+      ? content !== undefined
+        ? content
+        : decodeUtf8(bytes)
+      : null;
+  const inline = decodedText !== null;
 
   const contentHash = createHash("sha256").update(bytes).digest("hex");
   const filename = path.split("/").pop()!;
@@ -159,8 +181,8 @@ export async function putFile(userId: string, organizationId: string, params: Pu
   let newBlobKey: string | undefined;
 
   if (inline) {
-    data.content = content !== undefined ? content : new TextDecoder("utf-8").decode(bytes);
-  } else if (existingData?.blob_key && existingData.content_hash === contentHash) {
+    data.content = decodedText!;
+  } else if (ownsBlobKey(collection.id, existingData?.blob_key) && existingData!.content_hash === contentHash) {
     // Same bytes already stored — reuse the blob, no rewrite, quota-neutral.
     data.blob_key = existingData.blob_key;
   } else {
@@ -169,9 +191,8 @@ export async function putFile(userId: string, organizationId: string, params: Pu
     try {
       await getStorage().put(newBlobKey, bytes, mime);
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Blob storage write failed";
-      if (/not configured/i.test(message)) {
-        return { error: message, status: 501 };
+      if (isStorageNotConfigured(err)) {
+        return { error: err.message, status: 501 };
       }
       return { error: "Failed to write file to blob storage", status: 502 };
     }
@@ -199,9 +220,9 @@ export async function putFile(userId: string, organizationId: string, params: Pu
 
   // The replaced version pointed at a different blob — delete it and credit
   // the storage back. Best-effort: an orphaned blob must not fail the write.
-  if (existingData?.blob_key && existingData.content_hash !== contentHash) {
+  if (ownsBlobKey(collection.id, existingData?.blob_key) && existingData!.content_hash !== contentHash) {
     try {
-      await getStorage().delete([existingData.blob_key]);
+      await getStorage().delete([existingData!.blob_key!]);
       await releaseStorage({ organizationId, bytes: existingData.size });
     } catch (err) {
       console.error("Failed to delete superseded blob", existingData.blob_key, err);
@@ -223,13 +244,16 @@ export async function getFile(slug: string, userId: string, path: string) {
     return { ...toMetadata(data), content: data.content };
   }
 
+  if (!ownsBlobKey(access.collection.id, data.blob_key)) {
+    return { error: "File not found", status: 404 };
+  }
+
   let downloadUrl: string;
   try {
-    downloadUrl = await getStorage().getDownloadUrl(data.blob_key!);
+    downloadUrl = await getStorage().getDownloadUrl(data.blob_key);
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Blob storage read failed";
-    if (/not configured/i.test(message)) {
-      return { error: message, status: 501 };
+    if (isStorageNotConfigured(err)) {
+      return { error: err.message, status: 501 };
     }
     return { error: "Failed to resolve file download URL", status: 502 };
   }
@@ -282,7 +306,7 @@ export async function cleanupCollectionBlobs(collectionId: number): Promise<void
 
   const keys = rows
     .map((row) => (row.data as FileData | null)?.blob_key)
-    .filter((key): key is string => typeof key === "string");
+    .filter((key): key is string => ownsBlobKey(collectionId, key));
 
   if (keys.length === 0) return;
 

--- a/src/lib/storage/seam.integration.test.ts
+++ b/src/lib/storage/seam.integration.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Integration spec for src/lib/storage/seam.ts against a REAL S3-compatible
+// endpoint (MinIO). No mocks — real SigV4 requests over the wire.
+//
+// Auto-skipped when HUTCH_S3_ENDPOINT is not set, so plain `npm test` stays
+// green without any infrastructure.
+//
+// To run locally:
+//
+//   1. Start MinIO (creates the hutch-test bucket automatically):
+//        docker compose -f docker-compose.minio.yml up -d --wait
+//
+//   2. Run the suite with the storage env pointed at it:
+//        HUTCH_S3_ENDPOINT=http://127.0.0.1:9010 \
+//        HUTCH_S3_BUCKET=hutch-test \
+//        HUTCH_S3_ACCESS_KEY_ID=hutch-test \
+//        HUTCH_S3_SECRET_ACCESS_KEY=hutch-test-secret \
+//        HUTCH_S3_REGION=auto \
+//        npm test -- src/lib/storage/seam.integration.test.ts
+//
+//   (The implementation phase will add a `test:integration` npm script that
+//   wraps the above; package.json is upstream-shared so it is not touched
+//   here.)
+//
+//   3. Tear down:  docker compose -f docker-compose.minio.yml down -v
+// ---------------------------------------------------------------------------
+
+const configured = Boolean(process.env.HUTCH_S3_ENDPOINT)
+
+describe.skipIf(!configured)('storage seam — MinIO round trip', () => {
+  // Unique key per run so repeated runs never collide with leftovers.
+  const key = `integration-test/${Date.now()}-${Math.random().toString(36).slice(2)}/logo.png`
+  const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff])
+  const contentType = 'image/png'
+
+  let storage: {
+    put: (key: string, bytes: Uint8Array, contentType: string) => Promise<void>
+    delete: (keys: string[]) => Promise<void>
+    getDownloadUrl: (key: string) => Promise<string>
+  }
+
+  beforeAll(async () => {
+    // Specifier goes through a variable (+ @vite-ignore) so Vite defers
+    // resolution to runtime: pre-implementation, plain `npm test` must report
+    // this file as skipped — not as a transform-time unresolved import.
+    const seamModulePath = './seam'
+    const { getStorage } = await import(/* @vite-ignore */ seamModulePath)
+    storage = getStorage()
+  })
+
+  afterAll(async () => {
+    // Best-effort cleanup in case an assertion failed before the delete step.
+    try {
+      await storage.delete([key])
+    } catch {
+      // already deleted by the test — fine
+    }
+  })
+
+  it('put → presigned GET returns the exact bytes and content type', async () => {
+    await storage.put(key, bytes, contentType)
+
+    const url = await storage.getDownloadUrl(key)
+    const res = await fetch(url)
+
+    expect(res.ok).toBe(true)
+    expect(res.headers.get('content-type')).toContain(contentType)
+    const received = new Uint8Array(await res.arrayBuffer())
+    expect(Buffer.from(received).equals(Buffer.from(bytes))).toBe(true)
+  })
+
+  it('the presigned URL requires no additional auth headers', async () => {
+    const url = await storage.getDownloadUrl(key)
+    // Plain unauthenticated fetch — the SigV4 query params ARE the auth.
+    const res = await fetch(url, { headers: {} })
+    expect(res.ok).toBe(true)
+  })
+
+  it('delete removes the object; the presigned GET no longer succeeds', async () => {
+    await storage.delete([key])
+
+    const url = await storage.getDownloadUrl(key)
+    const res = await fetch(url)
+    expect(res.ok).toBe(false) // MinIO answers 404 NoSuchKey
+  })
+})

--- a/src/lib/storage/seam.test.ts
+++ b/src/lib/storage/seam.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Failing spec (TDD) for the storage seam:
+//   src/lib/storage/seam.ts — the ONLY place blob storage lives (mirrors the
+//   src/lib/auth/seam.ts pattern).
+//
+// getStorage(): Storage
+//   put(key: string, bytes: Uint8Array, contentType: string): Promise<void>
+//   delete(keys: string[]): Promise<void>
+//   getDownloadUrl(key: string): Promise<string>   // time-limited presigned GET
+//
+// Implementation signs requests with aws4fetch (SigV4) against any
+// S3-compatible endpoint, configured ONLY by env:
+//   HUTCH_S3_ENDPOINT, HUTCH_S3_BUCKET,
+//   HUTCH_S3_ACCESS_KEY_ID, HUTCH_S3_SECRET_ACCESS_KEY,
+//   HUTCH_S3_REGION (optional)
+//
+// When the env vars are absent, every storage op rejects with a clear
+// "storage not configured" error — callers (files service) surface it.
+//
+// These tests stub global fetch and assert the real signed requests, so they
+// stay valid regardless of how the seam wires aws4fetch internally.
+// ---------------------------------------------------------------------------
+
+const ENDPOINT = 'https://s3.example.test'
+const BUCKET = 'hutch-blobs'
+const ACCESS_KEY_ID = 'HUTCHACCESSKEYID0000'
+const SECRET_ACCESS_KEY = 'hutch-secret-access-key'
+
+const fetchMock = vi.fn()
+
+// aws4fetch may call fetch(Request) or fetch(url, init); normalize to Request.
+function requestAt(callIndex: number): Request {
+  const call = fetchMock.mock.calls[callIndex]
+  expect(call, `expected fetch call #${callIndex}`).toBeDefined()
+  return new Request(call[0] as RequestInfo, call[1] as RequestInit | undefined)
+}
+
+function stubConfiguredEnv() {
+  vi.stubEnv('HUTCH_S3_ENDPOINT', ENDPOINT)
+  vi.stubEnv('HUTCH_S3_BUCKET', BUCKET)
+  vi.stubEnv('HUTCH_S3_ACCESS_KEY_ID', ACCESS_KEY_ID)
+  vi.stubEnv('HUTCH_S3_SECRET_ACCESS_KEY', SECRET_ACCESS_KEY)
+}
+
+function stubUnconfiguredEnv() {
+  vi.stubEnv('HUTCH_S3_ENDPOINT', '')
+  vi.stubEnv('HUTCH_S3_BUCKET', '')
+  vi.stubEnv('HUTCH_S3_ACCESS_KEY_ID', '')
+  vi.stubEnv('HUTCH_S3_SECRET_ACCESS_KEY', '')
+}
+
+// Fresh module per test so the seam re-reads env regardless of whether it
+// caches config at module scope or at call time.
+async function loadSeam() {
+  vi.resetModules()
+  return await import('./seam')
+}
+
+// Wraps getStorage() + the op so the test passes whether the seam rejects the
+// op or getStorage() throws synchronously when unconfigured.
+async function withStorage<T>(fn: (storage: {
+  put: (key: string, bytes: Uint8Array, contentType: string) => Promise<void>
+  delete: (keys: string[]) => Promise<void>
+  getDownloadUrl: (key: string) => Promise<string>
+}) => Promise<T>): Promise<T> {
+  const { getStorage } = await loadSeam()
+  return await fn(getStorage())
+}
+
+beforeEach(() => {
+  fetchMock.mockReset().mockResolvedValue(new Response(null, { status: 200 }))
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+describe('put — signed PUT to {endpoint}/{bucket}/{key}', () => {
+  beforeEach(stubConfiguredEnv)
+
+  it('issues a SigV4-signed PUT carrying the bytes and content type', async () => {
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+    await withStorage((s) => s.put('blobs/1/abc123', bytes, 'image/png'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const req = requestAt(0)
+    expect(req.method).toBe('PUT')
+    expect(req.url).toBe(`${ENDPOINT}/${BUCKET}/blobs/1/abc123`)
+    expect(req.headers.get('content-type')).toBe('image/png')
+
+    const auth = req.headers.get('authorization')
+    expect(auth).toMatch(/AWS4-HMAC-SHA256/)
+    expect(auth).toContain(ACCESS_KEY_ID)
+
+    const body = new Uint8Array(await req.arrayBuffer())
+    expect(Buffer.from(body).equals(Buffer.from(bytes))).toBe(true)
+  })
+
+  it('rejects when the endpoint responds with a non-2xx status', async () => {
+    fetchMock.mockResolvedValue(new Response('AccessDenied', { status: 403 }))
+    await expect(
+      withStorage((s) => s.put('blobs/1/denied', new Uint8Array([1]), 'application/octet-stream'))
+    ).rejects.toThrow()
+  })
+})
+
+describe('delete — signed DELETE per key', () => {
+  beforeEach(stubConfiguredEnv)
+
+  it('issues one signed DELETE for each key', async () => {
+    await withStorage((s) => s.delete(['blobs/1/one', 'blobs/1/two']))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const urls = fetchMock.mock.calls.map((_, i) => requestAt(i)).map((r) => ({
+      method: r.method,
+      url: r.url,
+    }))
+    expect(urls).toEqual(expect.arrayContaining([
+      { method: 'DELETE', url: `${ENDPOINT}/${BUCKET}/blobs/1/one` },
+      { method: 'DELETE', url: `${ENDPOINT}/${BUCKET}/blobs/1/two` },
+    ]))
+    for (let i = 0; i < 2; i++) {
+      expect(requestAt(i).headers.get('authorization')).toMatch(/AWS4-HMAC-SHA256/)
+    }
+  })
+
+  it('resolves without fetching when the key list is empty', async () => {
+    await expect(withStorage((s) => s.delete([]))).resolves.toBeUndefined()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('getDownloadUrl — presigned GET URL', () => {
+  beforeEach(stubConfiguredEnv)
+
+  it('resolves to a time-limited presigned URL for the key (no network call)', async () => {
+    const url = await withStorage((s) => s.getDownloadUrl('blobs/1/abc123'))
+
+    expect(url.startsWith(`${ENDPOINT}/${BUCKET}/blobs/1/abc123`)).toBe(true)
+
+    const params = new URL(url).searchParams
+    expect(params.get('X-Amz-Algorithm')).toBe('AWS4-HMAC-SHA256')
+    expect(params.get('X-Amz-Signature')).toBeTruthy()
+    expect(params.get('X-Amz-Credential')).toContain(ACCESS_KEY_ID)
+    expect(params.get('X-Amz-Expires')).toBeTruthy() // time-limited
+
+    // Presigning is local crypto — no request leaves the process.
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('never leaks the secret access key into the URL', async () => {
+    const url = await withStorage((s) => s.getDownloadUrl('blobs/1/abc123'))
+    expect(url).not.toContain(SECRET_ACCESS_KEY)
+  })
+})
+
+describe('storage not configured — HUTCH_S3_* env absent', () => {
+  beforeEach(stubUnconfiguredEnv)
+
+  it('put rejects with a clear "storage not configured" error and never fetches', async () => {
+    await expect(
+      withStorage((s) => s.put('blobs/1/x', new Uint8Array([1]), 'application/octet-stream'))
+    ).rejects.toThrow(/not configured/i)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('delete rejects with a clear "storage not configured" error', async () => {
+    await expect(
+      withStorage((s) => s.delete(['blobs/1/x']))
+    ).rejects.toThrow(/not configured/i)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('getDownloadUrl rejects with a clear "storage not configured" error', async () => {
+    await expect(
+      withStorage((s) => s.getDownloadUrl('blobs/1/x'))
+    ).rejects.toThrow(/not configured/i)
+  })
+})
+
+describe('key validation — keys never escape the bucket', () => {
+  beforeEach(stubConfiguredEnv)
+
+  const badKeys: [string, string][] = [
+    ['empty key', ''],
+    ['absolute key', '/etc/passwd'],
+    ['leading .. segment', '../escape.bin'],
+    ['embedded .. segment', 'blobs/../../escape.bin'],
+    ['bare ..', '..'],
+  ]
+
+  for (const [label, key] of badKeys) {
+    it(`put rejects ${label} without fetching`, async () => {
+      await expect(
+        withStorage((s) => s.put(key, new Uint8Array([1]), 'application/octet-stream'))
+      ).rejects.toThrow()
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it(`delete rejects ${label} without fetching`, async () => {
+      await expect(withStorage((s) => s.delete([key]))).rejects.toThrow()
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it(`getDownloadUrl rejects ${label}`, async () => {
+      await expect(withStorage((s) => s.getDownloadUrl(key))).rejects.toThrow()
+    })
+  }
+})

--- a/src/lib/storage/seam.ts
+++ b/src/lib/storage/seam.ts
@@ -1,0 +1,127 @@
+import { AwsClient } from "aws4fetch";
+
+// The ONLY place blob storage lives (mirrors src/lib/auth/seam.ts). Signs
+// SigV4 requests via aws4fetch against any S3-compatible endpoint (AWS S3,
+// MinIO, R2, Tigris, ...), configured entirely by env:
+//
+//   HUTCH_S3_ENDPOINT           e.g. https://s3.amazonaws.com or http://127.0.0.1:9010
+//   HUTCH_S3_BUCKET
+//   HUTCH_S3_ACCESS_KEY_ID
+//   HUTCH_S3_SECRET_ACCESS_KEY
+//   HUTCH_S3_REGION             optional (default us-east-1; "auto" for R2/MinIO)
+//
+// When the env vars are absent every op rejects with a clear "storage not
+// configured" error — callers (the files service) surface it as HTTP 501.
+
+export interface Storage {
+  put(key: string, bytes: Uint8Array, contentType: string): Promise<void>;
+  delete(keys: string[]): Promise<void>;
+  /** Time-limited presigned GET URL — local crypto, no network call. */
+  getDownloadUrl(key: string): Promise<string>;
+}
+
+const DOWNLOAD_URL_EXPIRES_SECONDS = 900; // 15 minutes
+
+type StorageConfig = {
+  endpoint: string;
+  bucket: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  region: string;
+};
+
+// Read at call time (not module scope) so env changes are always honored.
+function readConfig(): StorageConfig | null {
+  const endpoint = process.env.HUTCH_S3_ENDPOINT;
+  const bucket = process.env.HUTCH_S3_BUCKET;
+  const accessKeyId = process.env.HUTCH_S3_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.HUTCH_S3_SECRET_ACCESS_KEY;
+  if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) return null;
+  return {
+    endpoint: endpoint.replace(/\/+$/, ""),
+    bucket,
+    accessKeyId,
+    secretAccessKey,
+    region: process.env.HUTCH_S3_REGION || "us-east-1",
+  };
+}
+
+function requireConfig(): StorageConfig {
+  const config = readConfig();
+  if (!config) {
+    throw new Error(
+      "Blob storage is not configured. Set the HUTCH_S3_* environment variables."
+    );
+  }
+  return config;
+}
+
+// Keys never escape the bucket: relative, non-empty, no '..' segments.
+function validateKey(key: string): string {
+  if (!key || key.startsWith("/") || key.includes("\0")) {
+    throw new Error(`Invalid storage key: ${JSON.stringify(key)}`);
+  }
+  if (key.split("/").some((segment) => segment === "..")) {
+    throw new Error(`Invalid storage key: ${JSON.stringify(key)}`);
+  }
+  return key;
+}
+
+function clientFor(config: StorageConfig): AwsClient {
+  return new AwsClient({
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    service: "s3",
+    region: config.region,
+  });
+}
+
+function objectUrl(config: StorageConfig, key: string): string {
+  return `${config.endpoint}/${config.bucket}/${key}`;
+}
+
+export function getStorage(): Storage {
+  return {
+    async put(key, bytes, contentType) {
+      const config = requireConfig();
+      validateKey(key);
+      const client = clientFor(config);
+      const res = await client.fetch(objectUrl(config, key), {
+        method: "PUT",
+        // Copy into a fresh ArrayBuffer-backed body (Uint8Array may be a view).
+        body: new Uint8Array(bytes),
+        headers: { "Content-Type": contentType },
+      });
+      if (!res.ok) {
+        throw new Error(`Blob storage PUT failed with status ${res.status}`);
+      }
+    },
+
+    async delete(keys) {
+      const config = requireConfig();
+      for (const key of keys) validateKey(key);
+      const client = clientFor(config);
+      await Promise.all(
+        keys.map(async (key) => {
+          const res = await client.fetch(objectUrl(config, key), { method: "DELETE" });
+          // 404 = already gone — deletion is idempotent.
+          if (!res.ok && res.status !== 404) {
+            throw new Error(`Blob storage DELETE failed with status ${res.status}`);
+          }
+        })
+      );
+    },
+
+    async getDownloadUrl(key) {
+      const config = requireConfig();
+      validateKey(key);
+      const client = clientFor(config);
+      const url = new URL(objectUrl(config, key));
+      url.searchParams.set("X-Amz-Expires", String(DOWNLOAD_URL_EXPIRES_SECONDS));
+      const signed = await client.sign(new Request(url, { method: "GET" }), {
+        aws: { signQuery: true },
+      });
+      return signed.url;
+    },
+  };
+}

--- a/src/lib/storage/seam.ts
+++ b/src/lib/storage/seam.ts
@@ -22,6 +22,13 @@ export interface Storage {
 
 const DOWNLOAD_URL_EXPIRES_SECONDS = 900; // 15 minutes
 
+export class StorageNotConfiguredError extends Error {
+  constructor() {
+    super("Blob storage is not configured. Set the HUTCH_S3_* environment variables.");
+    this.name = "StorageNotConfiguredError";
+  }
+}
+
 type StorageConfig = {
   endpoint: string;
   bucket: string;
@@ -49,16 +56,15 @@ function readConfig(): StorageConfig | null {
 function requireConfig(): StorageConfig {
   const config = readConfig();
   if (!config) {
-    throw new Error(
-      "Blob storage is not configured. Set the HUTCH_S3_* environment variables."
-    );
+    throw new StorageNotConfiguredError();
   }
   return config;
 }
 
-// Keys never escape the bucket: relative, non-empty, no '..' segments.
+// Keys never escape the bucket: relative, non-empty, no '..' segments, and no
+// characters that could smuggle query strings or subresources into the S3 URL.
 function validateKey(key: string): string {
-  if (!key || key.startsWith("/") || key.includes("\0")) {
+  if (!key || key.startsWith("/") || /[\0?#%\\]/.test(key)) {
     throw new Error(`Invalid storage key: ${JSON.stringify(key)}`);
   }
   if (key.split("/").some((segment) => segment === "..")) {
@@ -118,6 +124,9 @@ export function getStorage(): Storage {
       const client = clientFor(config);
       const url = new URL(objectUrl(config, key));
       url.searchParams.set("X-Amz-Expires", String(DOWNLOAD_URL_EXPIRES_SECONDS));
+      // Force download so attacker-chosen mime types can't execute in-browser
+      // on the storage origin.
+      url.searchParams.set("response-content-disposition", "attachment");
       const signed = await client.sign(new Request(url, { method: "GET" }), {
         aws: { signQuery: true },
       });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, configDefaults } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
@@ -7,6 +7,26 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     setupFiles: ['./vitest.setup.ts'],
-    include: ['src/**/*.test.{ts,tsx}'],
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'unit',
+          include: ['src/**/*.test.{ts,tsx}'],
+          exclude: [...configDefaults.exclude, 'src/**/*.integration.test.ts'],
+        },
+      },
+      {
+        // Integration tests hit real network endpoints (MinIO); happy-dom's
+        // browser-emulating fetch corrupts SigV4-signed requests, so these
+        // run in the plain node environment.
+        extends: true,
+        test: {
+          name: 'integration',
+          environment: 'node',
+          include: ['src/**/*.integration.test.ts'],
+        },
+      },
+    ],
   },
 })


### PR DESCRIPTION
## Summary
- Files are stored as records with the canonical shape `{path, filename, mime_type, size, content_hash, content?|blob_key?}` — reusing collection permissions, LWW upsert on `path`, and views. Two tiers: inline UTF-8 text ≤256KB in record JSON (zero-config), blobs ≤4MB via a new S3-compatible storage seam.
- New storage seam at `src/lib/storage/seam.ts` (aws4fetch SigV4, `HUTCH_S3_*` env, presigned time-limited download URLs) mirroring the auth seam's single-file overwrite pattern; quota seam gains no-op `beforeStoreFile`/`releaseStorage`.
- Surfaces: MCP tools `hutch_put_file` / `hutch_get_file` / `hutch_list_files`, and REST `PUT/GET/DELETE /api/v1/collections/[slug]/files/[...path]`. Collection delete reaps its blobs.
- Hardened per security review: blob keys trusted only inside the collection's own prefix, capped request-body buffering, nosniff + forced-download on served bytes, strict path/key validation, blob reap + quota credit on failed record writes.

## Test plan
- [x] `npm test` — 308 passed / 3 skipped (unit + mocked seam spec)
- [x] `npx tsc --noEmit` clean
- [x] MinIO-gated integration suite (`npm run test:integration` with `HUTCH_S3_*` set) — real put → presign → fetch → delete round-trip