### PR TITLE
Remove dormant submissions flag from collections

### DIFF
--- a/drizzle/0020_drop_collections_submissions.sql
+++ b/drizzle/0020_drop_collections_submissions.sql
@@ -1,0 +1,2 @@
+-- Drop the dormant per-collection submissions flag (dead plumbing in Core; no submit endpoint consumes it).
+ALTER TABLE "collections" DROP COLUMN IF EXISTS "submissions";

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1780444800000,
       "tag": "0019_invitation_email_lower_index",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1780531200000,
+      "tag": "0020_drop_collections_submissions",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/queries.test.ts
+++ b/src/lib/db/queries.test.ts
@@ -45,7 +45,6 @@ const collectionRow = {
   uniqueKey: null,
   published: false,
   publishedAt: null,
-  submissions: 'closed' as const,
   visibility: 'private',
   orgDefaultRole: 'viewer',
   createdAt: new Date(),

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -140,7 +140,6 @@ export const collections = pgTable("collections", {
   uniqueKey: jsonb("unique_key").default([]),
   published: boolean("published").default(false),
   publishedAt: timestamp("published_at", { withTimezone: true }),
-  submissions: text("submissions").default("closed"),
   visibility: text("visibility").notNull().default("private"),
   orgDefaultRole: text("org_default_role").notNull().default("viewer"),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -183,14 +183,13 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
   server.registerTool(
     "hutch_update_collection",
     {
-      description: "Update a collection's name, description, unique_key (for upsert dedup), published flag, or submissions setting. Example: use when the user wants to publish a collection or set a dedup key.",
+      description: "Update a collection's name, description, unique_key (for upsert dedup), or published flag. Example: use when the user wants to publish a collection or set a dedup key.",
       inputSchema: {
         slug: z.string().describe("Collection slug"),
         name: z.string().optional().describe("New collection name"),
         description: z.string().optional().describe("Collection description"),
         unique_key: z.array(z.string()).optional().describe("Fields that form the unique key for upsert (e.g. [\"url\"] or [\"email\", \"date\"])"),
         published: z.boolean().optional().describe("Whether the collection is publicly viewable"),
-        submissions: z.enum(["open", "closed"]).optional().describe("Whether public submissions are accepted"),
       },
       // destructiveHint: true because `published: true` exposes the collection to the public web.
       annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: false },

--- a/src/lib/services/collections-files-cleanup.test.ts
+++ b/src/lib/services/collections-files-cleanup.test.ts
@@ -82,7 +82,6 @@ const baseCollection = {
   description: null,
   published: false,
   publishedAt: null,
-  submissions: 'closed' as const,
   visibility: 'private',
   orgDefaultRole: 'viewer',
   createdAt: new Date(),

--- a/src/lib/services/collections.test.ts
+++ b/src/lib/services/collections.test.ts
@@ -96,7 +96,6 @@ const baseCollection = {
   description: null,
   published: false,
   publishedAt: null,
-  submissions: 'closed' as const,
   visibility: 'private',
   orgDefaultRole: 'viewer',
   createdAt: new Date(),
@@ -124,19 +123,18 @@ describe('createCollection', () => {
     expect(call.name).toBe('Bookmarks')
   })
 
-  it('passes through schema, unique_key, published, and submissions', async () => {
+  it('passes through schema, unique_key, and published', async () => {
     vi.mocked(createCollectionWithOwner).mockResolvedValue(baseCollection)
     await createCollection('user-test', 'org-test', {
       name: 'Bookmarks',
       schema: { fields: [{ name: 'url', type: 'text' }] },
       unique_key: ['url'],
       published: true,
-      submissions: 'open',
     })
     const call = vi.mocked(createCollectionWithOwner).mock.calls[0][0]
+    expect(call.schema).toEqual({ fields: [{ name: 'url', type: 'text' }] })
     expect(call.uniqueKey).toEqual(['url'])
     expect(call.published).toBe(true)
-    expect(call.submissions).toBe('open')
   })
 
   it('does NOT call seedAutoViews when no schema is supplied', async () => {

--- a/src/lib/services/collections.ts
+++ b/src/lib/services/collections.ts
@@ -169,7 +169,6 @@ export async function listCollections(userId: string, organizationId?: string) {
       schema: collections.schema,
       uniqueKey: collections.uniqueKey,
       published: collections.published,
-      submissions: collections.submissions,
       createdAt: collections.createdAt,
       updatedAt: collections.updatedAt,
       role: collectionMembers.role,
@@ -218,9 +217,8 @@ export async function createCollection(userId: string, organizationId: string, p
   schema?: unknown;
   unique_key?: unknown;
   published?: boolean;
-  submissions?: string;
 }) {
-  const { name, description, schema: schemaVal, unique_key, published, submissions } = params;
+  const { name, description, schema: schemaVal, unique_key, published } = params;
 
   const slug = uniqueSlug(name);
 
@@ -233,7 +231,6 @@ export async function createCollection(userId: string, organizationId: string, p
     schema: schemaVal ?? { fields: [] },
     uniqueKey: unique_key ?? [],
     published: published ?? false,
-    submissions: submissions ?? "closed",
   });
 
   if (schemaVal && (schemaVal as CollectionSchema)?.fields?.length) {
@@ -275,7 +272,6 @@ export async function updateCollection(slug: string, userId: string, updates: Re
   if (updates.description !== undefined) dbUpdates.description = updates.description;
   if (updates.schema !== undefined) dbUpdates.schema = updates.schema;
   if (updates.unique_key !== undefined) dbUpdates.uniqueKey = updates.unique_key;
-  if (updates.submissions !== undefined) dbUpdates.submissions = updates.submissions;
   if (updates.published !== undefined) {
     dbUpdates.published = updates.published;
     if (updates.published && !collection.publishedAt) {

--- a/src/lib/services/files.test.ts
+++ b/src/lib/services/files.test.ts
@@ -142,7 +142,6 @@ const fileCollection = {
   description: null,
   published: false,
   publishedAt: null,
-  submissions: 'closed' as const,
   visibility: 'private',
   orgDefaultRole: 'viewer',
   createdAt: new Date(),

--- a/src/lib/services/records.test.ts
+++ b/src/lib/services/records.test.ts
@@ -105,7 +105,6 @@ const baseCollection = {
   description: null,
   published: false,
   publishedAt: null,
-  submissions: 'closed' as const,
   visibility: 'private',
   orgDefaultRole: 'viewer',
   createdAt: new Date(),

--- a/src/lib/services/views.test.ts
+++ b/src/lib/services/views.test.ts
@@ -50,7 +50,6 @@ const collectionRow = {
   uniqueKey: null,
   published: false,
   publishedAt: null,
-  submissions: 'closed' as const,
   visibility: 'private',
   orgDefaultRole: 'viewer',
   createdAt: new Date(),


### PR DESCRIPTION
## What

Removes the per-collection **`submissions`** flag (`"open"`/`"closed"`) from the `collections` table. In Core this flag is **dead plumbing** — there is no public submit endpoint that reads it, so nothing ever consumed it. This is a straightforward dead-code / schema cleanup.

## Changes

- Drop the `submissions` column from the `collections` schema (migration `0020_drop_collections_submissions`, `DROP COLUMN IF EXISTS`).
- Remove its handling in the collections service (`listCollections` projection, `createCollection` default, `updateCollection` write path).
- Remove the `submissions` setting from the `hutch_update_collection` MCP tool (input + description).
- Drop the now-unused `submissions` fixture field from the affected service/query tests.

## Preserved

The `published` flag and all read/publish behavior are unchanged.

## Verification

- `tsc` clean; `vitest run` → 318 passed (3 pre-existing skips).
- `grep -rn "submissions" src` returns nothing in live code (only historical migration artifacts remain).

## Note

The migration file is committed but **not applied** here — apply via your normal migration flow.