### PR TITLE
MCP: filter operators, sum/avg, projection, collection stats, CSV/JSON export/import

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,8 @@ If you've configured [CLA Assistant](https://cla-assistant.io/) on this reposito
 ## Getting set up
 
 ```bash
-git clone https://github.com/ExpeditedProjects/hutch-core
-cd hutch-core
+git clone https://github.com/ExpeditedProjects/hutchdb
+cd hutchdb
 npm install
 cp .env.local.example .env.local
 # edit .env.local with your database URL and admin credentials

--- a/README.md
+++ b/README.md
@@ -1,113 +1,183 @@
-# Hutch Core
+<!-- Banner slot: drop a Plex Terminal banner at assets/banner.png and swap this in:
+<p align="center"><img src="assets/banner.png" alt="Hutch" width="100%" style="border-radius: 8px;" /></p>
+-->
 
-The simplest self-hostable MCP server for structured agent data.
+<h1 align="center">Hutch</h1>
 
-Hutch Core is headless, single-user, and batteries-not-included. Point an MCP client (Claude Code, Cursor, Codex, VS Code) at it, tell your agent "save this," and get a queryable, schema-optional JSONB record store — no dashboard, no login screens, no OAuth ceremony. Just an MCP endpoint and a Postgres database.
+<p align="center"><b>Put every AI agent on the same data.</b><br />
+Self-host a structured workspace that Claude Code, Codex, Cursor, and other MCP clients can read and update together.</p>
 
-This is the OSS engine. The multi-user product with a web dashboard, published views, social login, and org sharing is [Hutch Cloud](https://app.hutchdb.com) — see [What moved to Hutch Cloud](#what-moved-to-hutch-cloud) below.
+<p align="center">
+  <a href="https://hutchdb.com"><img src="https://img.shields.io/badge/Website-hutchdb.com-fbbf24" alt="Website" /></a>&nbsp;
+  <a href="https://app.hutchdb.com"><img src="https://img.shields.io/badge/Hutch-Cloud-fbbf24" alt="Hutch Cloud" /></a>&nbsp;
+  <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-compatible-blue" alt="MCP" /></a>&nbsp;
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/ExpeditedProjects/hutchdb" alt="License" /></a>
+</p>
 
-## Quickstart with Docker
+---
+
+## What is Hutch?
+
+Hutch Core is a **headless, single-user MCP server** that gives every agent you run the same durable, structured data. Connect Claude Code, Codex, Cursor, VS Code, or another MCP client and they can store, query, and update shared collections of records and files across sessions.
+
+Collections use schema-optional Postgres JSONB with full-text search, optional validation, and view definitions. There is **no dashboard, no login screen, and no OAuth ceremony** — just an MCP endpoint and a Postgres database you control.
+
+This repo is the OSS engine. If you want people and agents working from the same visual workspace, [Hutch Cloud](https://app.hutchdb.com) adds web views, published pages, social login, and organization sharing. See [Core vs Cloud](#hutch-core-vs-hutch-cloud) below.
+
+## What can you use it for?
+
+- **Store and share structured data.** Keep research, customer records, product data, files, and working context where every connected agent can find and update them.
+- **Run repeatable playbooks.** Store the instructions, steps, inputs, outputs, and current status for work that needs to survive beyond one chat.
+- **Hand work between agents.** Let one agent collect records, another process them, and a third report on the result without copying data between tools.
+- **Keep useful work across sessions.** Decisions, backlogs, and open threads remain queryable after the context window closes.
+
+Collections auto-create on the first write. Start with “save this to Hutch,” then query the same records from any connected agent.
+
+## Quick Start
+
+> **Note**: Full documentation lives at [hutchdb.com](https://hutchdb.com).
+
+1. **Clone and boot** (Docker):
+
+   ```bash
+   git clone https://github.com/ExpeditedProjects/hutchdb
+   cd hutchdb
+   docker compose up
+   ```
+
+   Core migrates the database and boots on port 3000. The singleton user and personal org are inserted lazily on the first request — there is no seed step.
+
+2. **Lock it down** (optional but recommended off-localhost) — require a bearer token on every MCP call by setting an API key before booting:
+
+   ```bash
+   export HUTCH_API_KEY="$(openssl rand -hex 32)"
+   ```
+
+   If unset, all requests are trusted — fine for localhost, not fine for a public host.
+
+3. **Connect your agent.** For Claude Code, add to your MCP config:
+
+   ```json
+   {
+     "mcpServers": {
+       "hutch": {
+         "type": "http",
+         "url": "http://localhost:3000/api/mcp",
+         "headers": {
+           "Authorization": "Bearer YOUR_HUTCH_API_KEY"
+         }
+       }
+     }
+   }
+   ```
+
+   Cursor, Codex, and VS Code accept the same HTTP MCP server shape — same `url`, same bearer header.
+
+4. **Use it.** Collections auto-create on first write — there is no setup step. Just talk to your agent:
+
+   > "Save these launch tasks to Hutch."
+   > "What did we store about the pricing research last week?"
+   > "Query the bug-reports collection for anything mentioning timeouts."
+
+5. **Verify the endpoint** (optional):
+
+   ```bash
+   curl -X POST http://localhost:3000/api/mcp \
+     -H "Authorization: Bearer $HUTCH_API_KEY" \
+     -H "Content-Type: application/json" \
+     -H "Accept: application/json, text/event-stream" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+   ```
+
+   You should see the `hutch_*` tool list (collections, records, schema, views, files).
+
+<details>
+<summary><b>Running without Docker</b></summary>
 
 ```bash
-git clone https://github.com/ExpeditedProjects/hutch-core
-cd hutch-core
-
-# Optional: require a bearer token on every MCP call.
-export HUTCH_API_KEY="$(openssl rand -hex 32)"
-
-docker compose up
-```
-
-Core migrates the database and boots on port 3000. The singleton user + personal org are inserted lazily on the first authenticated MCP or REST request — there is no seed step.
-
-## Quickstart without Docker
-
-```bash
-git clone https://github.com/ExpeditedProjects/hutch-core
-cd hutch-core
+git clone https://github.com/ExpeditedProjects/hutchdb
+cd hutchdb
 npm install
 cp .env.local.example .env.local
 # Required: HUTCH_DATABASE_URL
-# Optional: HUTCH_API_KEY (if unset, all requests are trusted — fine for
-# localhost, not fine for a public host)
+# Optional: HUTCH_API_KEY
 npm run db:migrate
 npm run dev
 ```
 
-The MCP endpoint is at `http://localhost:3111/api/mcp` (dev) or `http://localhost:3000/api/mcp` (production / Docker).
+The dev MCP endpoint is `http://localhost:3111/api/mcp` (production/Docker: port 3000).
 
-## Connecting an MCP client
+</details>
 
-If `HUTCH_API_KEY` is set, every MCP request must include an `Authorization: Bearer <key>` header. If it is unset, Core accepts anonymous requests (single-user local mode).
+## Example
 
-### Claude Code
+A typical session with Claude Code connected to a local Core instance:
 
-```json
-{
-  "mcpServers": {
-    "hutch": {
-      "type": "http",
-      "url": "http://localhost:3000/api/mcp",
-      "headers": {
-        "Authorization": "Bearer YOUR_HUTCH_API_KEY"
-      }
-    }
-  }
-}
+```text
+You:    Save each of these customer interviews as a record — tag the ones
+        that mention pricing.
+
+Agent:  Stored 9 records in `customer-interviews`, 4 tagged "pricing".
+
+You:    (a week later) Which interviewees complained about onboarding?
+
+Agent:  Querying `customer-interviews`... 3 records match: Dana R.,
+        Marcus T., and the anonymous Feb 12 call.
 ```
 
-### Cursor / VS Code
+Records are arbitrary JSON in Postgres JSONB — queryable via containment filters, Mongo-style operators (`$gt`, `$in`, `$exists`, `$contains`, …), and full-text search, with optional schemas when you want structure enforced. Collections export and import as CSV or JSON when data needs to move.
 
-Both accept the same HTTP MCP server shape as above — set the `url` to your Core endpoint and pass the bearer token in `headers.Authorization`.
+## Hutch Core vs Hutch Cloud
 
-### Testing the endpoint
+Core is intentionally small. If you want the product layer, run [Hutch Cloud](https://app.hutchdb.com) — or fork Core and build your own.
 
-```bash
-curl -X POST http://localhost:3000/api/mcp \
-  -H "Authorization: Bearer $HUTCH_API_KEY" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
-```
+| | Core (this repo) | [Hutch Cloud](https://app.hutchdb.com) |
+| --- | --- | --- |
+| MCP server (collections, records, schema, views, files) | ✅ | ✅ |
+| Self-hosted, single-user, static API key | ✅ | — |
+| Web dashboard, record grid, view editor | — | ✅ |
+| Published views + public pages | — | ✅ |
+| OAuth 2.1 authorization server + consent (read/write scopes) | — | ✅ |
+| Social login, sessions, multi-user orgs, invitations | — | ✅ |
+| Works with claude.ai (web) | — | ✅ |
 
-You should see the list of `hutch_*` tools (collections, records, schema, views).
-
-## What moved to Hutch Cloud
-
-Core is intentionally small. If you want any of these, either run [Hutch Cloud](https://app.hutchdb.com) or fork Core and add them yourself:
-
-- Web dashboard (`/dashboard`, collection browser, record grid, view editor)
-- Published views and public read-only pages (`/p/[slug]`, submission forms)
-- OAuth 2.1 authorization server (`/api/oauth/*`, `/.well-known/oauth-*`)
-- Social login (GitHub, Google), password auth, session cookies
-- Multi-user organizations, invitations, member roles, sharing
-- Email delivery for invitations
-- Quota enforcement / billing hooks
-
-> **claude.ai web requires OAuth.** Because Core does not ship an OAuth authorization server, adding a Core instance to claude.ai (the web app) will not work out of the box — that flow needs Hutch Cloud, or you need to layer your own OAuth AS in front of Core. Claude Code, Cursor, Codex, and VS Code all accept a static bearer token and work fine.
+> **claude.ai requires OAuth.** Core ships no OAuth authorization server, so adding a Core instance to claude.ai (web) won't work out of the box. Claude Code, Cursor, Codex, and VS Code all accept a static bearer token and work fine.
 
 ## Architecture
 
-- **Next.js 16 App Router** — one static landing page, one MCP route (`/api/mcp`), one REST seed route (`/api/v1/collections`). Everything else is deleted.
+- **Next.js App Router** — one static landing page, one MCP route (`/api/mcp`), one REST seed route (`/api/v1/collections`). Everything else is deleted.
 - **Drizzle + Postgres** — records stored as JSONB, queried via containment operators and full-text search.
-- **MCP server** — collection tools, record tools (store/query/search/update/delete/status/transform), schema tools (describe/infer/update), view tools, file tools (put/get/list — small text files store inline; binary or >256KB files use S3-compatible blob storage via the optional `HUTCH_S3_*` env vars).
-- **Auth seam** at `src/lib/auth/seam.ts` — if `HUTCH_API_KEY` is set, `authenticate()` requires a matching `Authorization: Bearer <key>`; otherwise it resolves the singleton context. The seam is the only place auth lives.
-- **Singleton bootstrap** at `src/lib/auth/singleton.ts` — one user, one personal org, inserted lazily on first request.
+- **MCP server** — collection tools (including per-collection stats), record tools (store/query/search/update/delete/status/transform plus CSV/JSON export and import), schema tools (describe/infer/update), view tools, and file tools (small text inline; binary or >256KB via S3-compatible storage with the optional `HUTCH_S3_*` env vars). Queries support filter operators (`$gt`/`$gte`/`$lt`/`$lte`/`$ne`/`$in`/`$nin`/`$exists`/`$contains`), field projection, and count/min/max/distinct/sum/avg aggregations.
+- **Auth seam** (`src/lib/auth/seam.ts`) — the only place auth lives: bearer-key check when `HUTCH_API_KEY` is set, singleton context otherwise.
+- **Singleton bootstrap** (`src/lib/auth/singleton.ts`) — one user, one personal org, created lazily on first request.
 
-## Smoke test
+## Contributing
+
+- **Found a bug?** [Open an issue](https://github.com/ExpeditedProjects/hutchdb/issues) with repro steps.
+- **Want to improve Core?** PRs welcome — contributors sign a CLA so the maintainer can dual-license into Hutch Cloud. See [CONTRIBUTING.md](CONTRIBUTING.md) and [CLA.md](CLA.md).
+- **Feedback or ideas?** Issues are the front door; tell us what you're building.
+
+<details>
+<summary><b>Development</b></summary>
 
 ```bash
-# Anonymous mode (HUTCH_API_KEY unset)
-SMOKE_BASE_URL=http://localhost:3000 npm run smoke
-
-# Keyed mode
-SMOKE_BASE_URL=http://localhost:3000 SMOKE_API_KEY=... npm run smoke
+npm test          # vitest
+npm run smoke     # end-to-end smoke test against a running instance:
+                  #   SMOKE_BASE_URL=http://localhost:3000 npm run smoke
+                  #   (keyed mode: add SMOKE_API_KEY=...)
 ```
+
+**Status**: stable enough for a single-user self-host. Breaking changes land on `main`; pin a commit if you need stability.
+
+</details>
 
 ## License
 
-AGPL v3 — see [LICENSE](LICENSE). Contributors sign a CLA so the maintainer can dual-license into Hutch Cloud — see [CONTRIBUTING.md](CONTRIBUTING.md) and [CLA.md](CLA.md).
+[AGPL v3](LICENSE).
 
-## Status
-
-Core is stable enough for a single-user self-host. Breaking changes land on `main`; pin a commit if you need stability.
+<p align="center">
+  <a href="https://github.com/ExpeditedProjects/hutchdb/stargazers"><img src="https://img.shields.io/github/stars/ExpeditedProjects/hutchdb?style=social" alt="GitHub stars" /></a>&nbsp;
+  <a href="https://github.com/ExpeditedProjects/hutchdb/issues"><img src="https://img.shields.io/github/issues/ExpeditedProjects/hutchdb" alt="Issues" /></a>&nbsp;
+  <a href="https://github.com/ExpeditedProjects/hutchdb/commits/main"><img src="https://img.shields.io/github/last-commit/ExpeditedProjects/hutchdb" alt="Last commit" /></a>&nbsp;
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/ExpeditedProjects/hutchdb" alt="License" /></a>
+</p>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,8 +20,8 @@ Hutch is a standard Next.js + Postgres app. Nothing forces a specific host — p
 Brings up Hutch and Postgres together with one command.
 
 ```bash
-git clone https://github.com/ExpeditedProjects/hutch-core
-cd hutch-core
+git clone https://github.com/ExpeditedProjects/hutchdb
+cd hutchdb
 
 export HUTCH_ADMIN_PASSWORD="change-me"
 export HUTCH_SESSION_SECRET="$(openssl rand -hex 32)"
@@ -56,8 +56,8 @@ If you'd rather run Postgres separately (managed RDS, Supabase, Neon, your own s
 For VPS or homelab deployments without Docker.
 
 ```bash
-git clone https://github.com/ExpeditedProjects/hutch-core
-cd hutch-core
+git clone https://github.com/ExpeditedProjects/hutchdb
+cd hutchdb
 npm ci
 
 # Set env vars however your platform expects (export, .env.local,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,6 @@
 export const RECORD_STATUSES = ["active", "pending", "flagged", "archived"] as const;
 export type RecordStatus = (typeof RECORD_STATUSES)[number];
+export const DEFAULT_RECORD_STATUS: RecordStatus = "active";
 
 // Type detection regex patterns — shared between schema-inference (server) and SmartCell (client)
 export const IMAGE_EXTENSIONS = /\.(jpg|jpeg|png|gif|webp|svg|avif|bmp|ico)(\?.*)?$/i;

--- a/src/lib/csv.test.ts
+++ b/src/lib/csv.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest'
+import {
+  escapeCsvField,
+  toCsv,
+  parseCsv,
+  coerceCsvValue,
+  recordsToCsv,
+  csvToRecords,
+  type ExportRow,
+} from './csv'
+
+describe('escapeCsvField (RFC 4180)', () => {
+  it('leaves plain values unquoted', () => {
+    expect(escapeCsvField('hello')).toBe('hello')
+  })
+
+  it('quotes values containing commas', () => {
+    expect(escapeCsvField('a,b')).toBe('"a,b"')
+  })
+
+  it('quotes and doubles embedded quotes', () => {
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""')
+  })
+
+  it('quotes values containing newlines', () => {
+    expect(escapeCsvField('line1\nline2')).toBe('"line1\nline2"')
+    expect(escapeCsvField('line1\r\nline2')).toBe('"line1\r\nline2"')
+  })
+})
+
+describe('parseCsv', () => {
+  it('parses a simple grid', () => {
+    expect(parseCsv('a,b\r\n1,2\r\n')).toEqual([['a', 'b'], ['1', '2']])
+  })
+
+  it('handles LF-only and CRLF line endings', () => {
+    expect(parseCsv('a,b\n1,2\n')).toEqual([['a', 'b'], ['1', '2']])
+  })
+
+  it('parses quoted fields with embedded commas', () => {
+    expect(parseCsv('a\r\n"x, y"\r\n')).toEqual([['a'], ['x, y']])
+  })
+
+  it('parses doubled quotes inside quoted fields', () => {
+    expect(parseCsv('a\r\n"say ""hi"""\r\n')).toEqual([['a'], ['say "hi"']])
+  })
+
+  it('parses embedded newlines inside quoted fields', () => {
+    expect(parseCsv('a,b\r\n"line1\r\nline2",2\r\n')).toEqual([['a', 'b'], ['line1\r\nline2', '2']])
+  })
+
+  it('handles empty cells and a trailing newline without a phantom row', () => {
+    expect(parseCsv('a,b,c\r\n1,,3\r\n')).toEqual([['a', 'b', 'c'], ['1', '', '3']])
+  })
+
+  it('round-trips through toCsv for adversarial values', () => {
+    const rows = [['plain', 'has,comma', 'has "quotes"', 'multi\nline', '']]
+    const parsed = parseCsv(toCsv(['a', 'b', 'c', 'd', 'e'], rows))
+    expect(parsed).toEqual([['a', 'b', 'c', 'd', 'e'], ...rows])
+  })
+})
+
+describe('coerceCsvValue', () => {
+  it('returns undefined for empty cells (field omitted)', () => {
+    expect(coerceCsvValue('')).toBeUndefined()
+  })
+
+  it('coerces booleans', () => {
+    expect(coerceCsvValue('true')).toBe(true)
+    expect(coerceCsvValue('false')).toBe(false)
+  })
+
+  it('coerces numeric strings to numbers', () => {
+    expect(coerceCsvValue('42')).toBe(42)
+    expect(coerceCsvValue('-3.14')).toBe(-3.14)
+    expect(coerceCsvValue('0')).toBe(0)
+  })
+
+  it('keeps leading-zero and non-numeric strings as strings', () => {
+    expect(coerceCsvValue('007')).toBe('007')
+    expect(coerceCsvValue('1.2.3')).toBe('1.2.3')
+    expect(coerceCsvValue('2026-08-22')).toBe('2026-08-22')
+  })
+
+  it('parses JSON-looking cells so nested values round-trip', () => {
+    expect(coerceCsvValue('{"a":1}')).toEqual({ a: 1 })
+    expect(coerceCsvValue('[1,2]')).toEqual([1, 2])
+  })
+
+  it('keeps invalid JSON-looking cells as strings', () => {
+    expect(coerceCsvValue('{not json')).toBe('{not json')
+  })
+})
+
+describe('recordsToCsv', () => {
+  const rows: ExportRow[] = [
+    {
+      id: 1,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-02T00:00:00.000Z',
+      data: { title: 'First', tags: ['a', 'b'] },
+    },
+    {
+      id: 2,
+      created_at: '2026-01-03T00:00:00.000Z',
+      updated_at: '2026-01-04T00:00:00.000Z',
+      data: { title: 'Second, with comma', extra: { nested: true } },
+    },
+  ]
+
+  it('emits system columns first, then the union of data keys in first-seen order', () => {
+    const csv = recordsToCsv(rows)
+    const [header] = parseCsv(csv)
+    expect(header).toEqual(['id', 'created_at', 'updated_at', 'title', 'tags', 'extra'])
+  })
+
+  it('JSON-stringifies nested objects and arrays into cells', () => {
+    const parsed = parseCsv(recordsToCsv(rows))
+    expect(parsed[1][4]).toBe('["a","b"]')
+    expect(parsed[2][5]).toBe('{"nested":true}')
+  })
+
+  it('leaves cells empty for records missing a key', () => {
+    const parsed = parseCsv(recordsToCsv(rows))
+    expect(parsed[1][5]).toBe('') // row 1 has no `extra`
+    expect(parsed[2][4]).toBe('') // row 2 has no `tags`
+  })
+})
+
+describe('csvToRecords', () => {
+  it('requires a header row', () => {
+    expect(csvToRecords('')).toEqual(expect.objectContaining({ error: expect.any(String) }))
+  })
+
+  it('infers types and omits empty cells', () => {
+    const result = csvToRecords('name,age,active,note\r\nAlice,30,true,\r\nBob,007,false,hello\r\n')
+    expect(result).toEqual({
+      records: [
+        { name: 'Alice', age: 30, active: true },
+        { name: 'Bob', age: '007', active: false, note: 'hello' },
+      ],
+    })
+  })
+
+  it('ignores system columns so exports round-trip without polluting data', () => {
+    const result = csvToRecords('id,created_at,updated_at,title\r\n1,2026-01-01,2026-01-02,Hello\r\n')
+    expect(result).toEqual({ records: [{ title: 'Hello' }] })
+  })
+
+  it('skips fully-empty rows', () => {
+    const result = csvToRecords('a,b\r\n1,2\r\n,\r\n3,4\r\n')
+    expect(result).toEqual({ records: [{ a: 1, b: 2 }, { a: 3, b: 4 }] })
+  })
+
+  it('handles quoted values with commas, quotes, and newlines', () => {
+    const result = csvToRecords('note\r\n"has, comma"\r\n"say ""hi"""\r\n"line1\nline2"\r\n')
+    expect(result).toEqual({
+      records: [{ note: 'has, comma' }, { note: 'say "hi"' }, { note: 'line1\nline2' }],
+    })
+  })
+})
+
+describe('export -> import round-trip', () => {
+  it('recordsToCsv output parses back to the original data via csvToRecords', () => {
+    const original: ExportRow[] = [
+      {
+        id: 10,
+        created_at: '2026-05-01T12:00:00.000Z',
+        updated_at: '2026-05-02T12:00:00.000Z',
+        data: {
+          title: 'Widget, deluxe "edition"',
+          price: 19.99,
+          in_stock: true,
+          tags: ['a', 'b'],
+          meta: { color: 'red', sizes: [1, 2] },
+          notes: 'first line\nsecond line',
+        },
+      },
+      {
+        id: 11,
+        created_at: '2026-05-03T12:00:00.000Z',
+        updated_at: '2026-05-04T12:00:00.000Z',
+        data: { title: 'Gadget', price: 5, in_stock: false },
+      },
+    ]
+
+    const result = csvToRecords(recordsToCsv(original))
+    expect(result).toEqual({ records: original.map((r) => r.data) })
+  })
+})

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,185 @@
+/**
+ * Zero-dependency RFC 4180 CSV serialization and parsing for record
+ * export/import. Records travel as flat rows: system columns
+ * (id, created_at, updated_at) first, then the union of top-level data
+ * keys in first-seen order. Nested objects/arrays are JSON-stringified
+ * into the cell on export and parsed back on import.
+ */
+
+/** System columns emitted first on export and ignored on import. */
+export const CSV_SYSTEM_COLUMNS = ["id", "created_at", "updated_at"] as const;
+
+/** A record row shaped for export. */
+export type ExportRow = {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  data: Record<string, unknown>;
+};
+
+/** Quote a single CSV field per RFC 4180 (only when it needs it). */
+export function escapeCsvField(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function cellValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return JSON.stringify(value);
+}
+
+/** Serialize a header row + data rows to CSV text (CRLF line endings). */
+export function toCsv(headers: string[], rows: string[][]): string {
+  const lines = [headers.map(escapeCsvField).join(",")];
+  for (const row of rows) {
+    lines.push(row.map(escapeCsvField).join(","));
+  }
+  return lines.join("\r\n") + "\r\n";
+}
+
+/**
+ * Serialize export rows to CSV. Header is id, created_at, updated_at,
+ * then the union of top-level data keys across all rows (first-seen order).
+ */
+export function recordsToCsv(rows: ExportRow[]): string {
+  const dataKeys: string[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row.data)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        dataKeys.push(key);
+      }
+    }
+  }
+
+  const headers = [...CSV_SYSTEM_COLUMNS, ...dataKeys];
+  const body = rows.map((row) => [
+    String(row.id),
+    row.created_at,
+    row.updated_at,
+    ...dataKeys.map((key) => cellValue(row.data[key])),
+  ]);
+  return toCsv(headers, body);
+}
+
+/**
+ * Parse CSV text into rows of string cells. Handles quoted fields with
+ * embedded commas, double-quote escapes, and CR/LF/CRLF newlines.
+ */
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  let i = 0;
+
+  const endField = () => {
+    row.push(field);
+    field = "";
+  };
+  const endRow = () => {
+    endField();
+    rows.push(row);
+    row = [];
+  };
+
+  while (i < text.length) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i += 2;
+        } else {
+          inQuotes = false;
+          i++;
+        }
+      } else {
+        field += ch;
+        i++;
+      }
+    } else if (ch === '"' && field === "") {
+      inQuotes = true;
+      i++;
+    } else if (ch === ",") {
+      endField();
+      i++;
+    } else if (ch === "\r") {
+      if (text[i + 1] === "\n") i++;
+      endRow();
+      i++;
+    } else if (ch === "\n") {
+      endRow();
+      i++;
+    } else {
+      field += ch;
+      i++;
+    }
+  }
+  if (field !== "" || row.length > 0) endRow();
+  return rows;
+}
+
+/**
+ * Infer a JSON value from a CSV cell: numeric strings become numbers,
+ * "true"/"false" become booleans, JSON-looking cells ({...} or [...])
+ * are parsed so nested values round-trip through export, everything
+ * else stays a string. Empty cells return undefined (field omitted).
+ */
+export function coerceCsvValue(raw: string): unknown {
+  if (raw === "") return undefined;
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (/^-?(0|[1-9]\d*)(\.\d+)?$/.test(raw)) {
+    const n = Number(raw);
+    if (Number.isFinite(n)) return n;
+  }
+  if (raw.startsWith("{") || raw.startsWith("[")) {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      // Not valid JSON — keep as string.
+    }
+  }
+  return raw;
+}
+
+/**
+ * Parse CSV text (header row required) into record data objects.
+ * System columns (id, created_at, updated_at) are ignored so
+ * hutch_export_records output round-trips cleanly. Fully-empty rows
+ * are skipped.
+ */
+export function csvToRecords(content: string): { records: Record<string, unknown>[] } | { error: string } {
+  const rows = parseCsv(content);
+  if (rows.length === 0) {
+    return { error: "CSV content is empty — a header row is required" };
+  }
+
+  const headers = rows[0].map((h) => h.trim());
+  if (headers.every((h) => h === "")) {
+    return { error: "CSV header row is empty — column names are required" };
+  }
+
+  const systemColumns = new Set<string>(CSV_SYSTEM_COLUMNS);
+  const records: Record<string, unknown>[] = [];
+
+  for (const cells of rows.slice(1)) {
+    if (cells.every((cell) => cell === "")) continue;
+    const record: Record<string, unknown> = {};
+    for (let c = 0; c < headers.length; c++) {
+      const header = headers[c];
+      if (header === "" || systemColumns.has(header)) continue;
+      const value = coerceCsvValue(cells[c] ?? "");
+      if (value !== undefined) record[header] = value;
+    }
+    records.push(record);
+  }
+
+  return { records };
+}

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -9,6 +9,8 @@
 /** System columns emitted first on export and ignored on import. */
 export const CSV_SYSTEM_COLUMNS = ["id", "created_at", "updated_at"] as const;
 
+const CSV_SYSTEM_COLUMN_SET = new Set<string>(CSV_SYSTEM_COLUMNS);
+
 /** A record row shaped for export. */
 export type ExportRow = {
   id: number;
@@ -166,7 +168,6 @@ export function csvToRecords(content: string): { records: Record<string, unknown
     return { error: "CSV header row is empty — column names are required" };
   }
 
-  const systemColumns = new Set<string>(CSV_SYSTEM_COLUMNS);
   const records: Record<string, unknown>[] = [];
 
   for (const cells of rows.slice(1)) {
@@ -174,7 +175,7 @@ export function csvToRecords(content: string): { records: Record<string, unknown
     const record: Record<string, unknown> = {};
     for (let c = 0; c < headers.length; c++) {
       const header = headers[c];
-      if (header === "" || systemColumns.has(header)) continue;
+      if (header === "" || CSV_SYSTEM_COLUMN_SET.has(header)) continue;
       const value = coerceCsvValue(cells[c] ?? "");
       if (value !== undefined) record[header] = value;
     }

--- a/src/lib/db/queries.test.ts
+++ b/src/lib/db/queries.test.ts
@@ -226,6 +226,17 @@ describe('buildFilterConditions', () => {
     it('rejects non-array operands', () => {
       expect(() => buildFilterConditions({ f: { $in: 'active' } })).toThrow(/array/)
     })
+
+    it('rejects arrays with more than 1000 elements', () => {
+      const big = Array.from({ length: 1001 }, (_, i) => i)
+      expect(() => buildFilterConditions({ f: { $in: big } })).toThrow(/limited to 1000 elements/)
+      expect(() => buildFilterConditions({ f: { $nin: big } })).toThrow(/limited to 1000 elements/)
+    })
+
+    it('accepts arrays at exactly 1000 elements', () => {
+      const atLimit = Array.from({ length: 1000 }, (_, i) => i)
+      expect(() => buildFilterConditions({ f: { $in: atLimit } })).not.toThrow()
+    })
   })
 
   describe('$exists', () => {
@@ -340,6 +351,26 @@ describe('queryRecords aggregation', () => {
       .rejects.toThrow(/Invalid field name/)
   })
 
+  it('rejects a groupBy field with any invalid character, naming the field', async () => {
+    await expect(queryRecords({ collectionId: 1, groupBy: 'name; DROP TABLE records--' }))
+      .rejects.toThrow(/Invalid field name 'name; DROP TABLE records--'/)
+  })
+
+  it('rejects an unknown aggregation op with the supported list', async () => {
+    await expect(queryRecords({ collectionId: 1, aggregate: { m: { median: 'price' } } }))
+      .rejects.toThrow(/Unsupported aggregation 'median'\. Supported: count, min, max, distinct, sum, avg/)
+  })
+
+  it('rejects a bare string aggregation spec other than count', async () => {
+    await expect(queryRecords({ collectionId: 1, aggregate: { total: 'sum' } }))
+      .rejects.toThrow(/Unsupported aggregation 'sum'/)
+  })
+
+  it('rejects an empty object aggregation spec', async () => {
+    await expect(queryRecords({ collectionId: 1, aggregate: { x: {} } }))
+      .rejects.toThrow(/Unsupported aggregation '\{\}'/)
+  })
+
   describe('sum and avg', () => {
     async function aggregationSql(aggregate: Record<string, Record<string, string>>): Promise<string> {
       dbExecute.mockResolvedValue({ rows: [] })
@@ -357,10 +388,11 @@ describe('queryRecords aggregation', () => {
       expect(sql).toContain(`avg(CASE WHEN jsonb_typeof(data->'price') = 'number' THEN (data->>'price')::numeric END) as "mean"`)
     })
 
-    it('sanitizes field and alias names in sum/avg specs', async () => {
-      const sql = await aggregationSql({ 'x"; DROP TABLE records--': { sum: "a'; --" } })
-      expect(sql).not.toContain('DROP TABLE')
-      expect(sql).not.toContain("'; --")
+    it('rejects field and alias names with invalid characters instead of stripping them', async () => {
+      await expect(queryRecords({ collectionId: 1, aggregate: { 'x"; DROP TABLE records--': { sum: 'amount' } } }))
+        .rejects.toThrow(/Invalid field name 'x"; DROP TABLE records--'/)
+      await expect(queryRecords({ collectionId: 1, aggregate: { revenue: { sum: "a'; --" } } }))
+        .rejects.toThrow(/Invalid field name 'a'; --'/)
     })
 
     it('existing min/max/distinct specs are unchanged', async () => {

--- a/src/lib/db/queries.test.ts
+++ b/src/lib/db/queries.test.ts
@@ -29,10 +29,21 @@ vi.mock('./index', () => ({
   },
 }))
 
+import { PgDialect } from 'drizzle-orm/pg-core'
+import type { SQL } from 'drizzle-orm'
 import {
   findAccessibleCollectionBySlug,
   queryRecords,
+  buildFilterConditions,
 } from './queries'
+
+// Serialize a drizzle SQL chunk to { sql, params } so tests can assert on
+// the generated (fully parameterized) SQL without a live database.
+const dialect = new PgDialect()
+function render(chunk: SQL): { sql: string; params: unknown[] } {
+  const { sql, params } = dialect.sqlToQuery(chunk)
+  return { sql, params }
+}
 
 const collectionRow = {
   id: 1,
@@ -109,6 +120,202 @@ describe('findAccessibleCollectionBySlug', () => {
   })
 })
 
+describe('buildFilterConditions', () => {
+  it('compiles a plain filter to a single containment condition (backwards compatible)', () => {
+    const conditions = buildFilterConditions({ status: 'active', priority: 1 })
+    expect(conditions).toHaveLength(1)
+    const { sql, params } = render(conditions[0])
+    expect(sql).toContain('@>')
+    expect(params).toEqual([JSON.stringify({ status: 'active', priority: 1 })])
+  })
+
+  it('treats nested plain objects and arrays as containment, not operators', () => {
+    const conditions = buildFilterConditions({ meta: { color: 'red' }, tags: ['a'] })
+    expect(conditions).toHaveLength(1)
+    const { params } = render(conditions[0])
+    expect(params).toEqual([JSON.stringify({ meta: { color: 'red' }, tags: ['a'] })])
+  })
+
+  it('treats an object with mixed $ and plain keys as containment', () => {
+    const conditions = buildFilterConditions({ f: { $gt: 1, plain: 2 } })
+    expect(conditions).toHaveLength(1)
+    expect(render(conditions[0]).sql).toContain('@>')
+  })
+
+  it('keeps containment first when plain and operator pairs are mixed', () => {
+    const conditions = buildFilterConditions({ status: 'active', price: { $gte: 10 } })
+    expect(conditions).toHaveLength(2)
+    expect(render(conditions[0]).sql).toContain('@>')
+    expect(render(conditions[1]).sql).toContain('jsonb_typeof')
+  })
+
+  describe('comparison operators ($gt/$gte/$lt/$lte)', () => {
+    it('guards numeric operands with jsonb_typeof = number and casts to numeric', () => {
+      const [cond] = buildFilterConditions({ price: { $gt: 5 } })
+      const { sql, params } = render(cond)
+      expect(sql).toMatch(/jsonb_typeof\("records"\."data"->\$\d+\) = 'number'/)
+      expect(sql).toContain('::numeric >')
+      expect(params).toEqual(['price', 'price', 5])
+    })
+
+    it('compares string operands lexicographically as text (mixed-type safe)', () => {
+      const [cond] = buildFilterConditions({ due: { $lt: '2026-09-01' } })
+      const { sql, params } = render(cond)
+      expect(sql).toMatch(/jsonb_typeof\("records"\."data"->\$\d+\) = 'string'/)
+      expect(sql).not.toContain('::numeric')
+      expect(params).toContain('2026-09-01')
+    })
+
+    it('maps each operator to its SQL comparator', () => {
+      const cases: [string, string][] = [['$gt', '>'], ['$gte', '>='], ['$lt', '<'], ['$lte', '<=']]
+      for (const [op, symbol] of cases) {
+        const [cond] = buildFilterConditions({ n: { [op]: 1 } })
+        expect(render(cond).sql).toContain(`::numeric ${symbol} `)
+      }
+    })
+
+    it('compiles a range spec ({$gte, $lt}) to two conditions', () => {
+      const conditions = buildFilterConditions({ price: { $gte: 10, $lt: 100 } })
+      expect(conditions).toHaveLength(2)
+      expect(render(conditions[0]).sql).toContain('>=')
+      expect(render(conditions[1]).sql).toContain('<')
+    })
+
+    it('rejects boolean/null/object operands', () => {
+      expect(() => buildFilterConditions({ f: { $gt: true } })).toThrow(/\$gt/)
+      expect(() => buildFilterConditions({ f: { $lte: null } })).toThrow(/\$lte/)
+    })
+  })
+
+  describe('$ne', () => {
+    it('negates containment (also matches records missing the field)', () => {
+      const [cond] = buildFilterConditions({ status: { $ne: 'archived' } })
+      const { sql, params } = render(cond)
+      expect(sql).toMatch(/^NOT \(/i)
+      expect(sql).toContain('@>')
+      expect(params).toEqual([JSON.stringify({ status: 'archived' })])
+    })
+  })
+
+  describe('$in / $nin', () => {
+    it('$in compiles to = ANY over parameterized jsonb values', () => {
+      const [cond] = buildFilterConditions({ status: { $in: ['active', 'pending'] } })
+      const { sql, params } = render(cond)
+      expect(sql).toContain('= ANY(ARRAY[')
+      expect(params).toEqual(['status', '"active"', '"pending"'])
+    })
+
+    it('$in supports mixed value types safely (jsonb equality, no casts)', () => {
+      const [cond] = buildFilterConditions({ f: { $in: [1, 'one', true] } })
+      const { sql, params } = render(cond)
+      expect(sql).not.toContain('::numeric')
+      expect(params).toEqual(['f', '1', '"one"', 'true'])
+    })
+
+    it('$nin also matches records missing the field', () => {
+      const [cond] = buildFilterConditions({ status: { $nin: ['archived'] } })
+      const { sql } = render(cond)
+      expect(sql).toContain('IS NULL OR NOT')
+    })
+
+    it('$in [] matches nothing; $nin [] matches everything', () => {
+      expect(render(buildFilterConditions({ f: { $in: [] } })[0]).sql).toBe('false')
+      expect(render(buildFilterConditions({ f: { $nin: [] } })[0]).sql).toBe('true')
+    })
+
+    it('rejects non-array operands', () => {
+      expect(() => buildFilterConditions({ f: { $in: 'active' } })).toThrow(/array/)
+    })
+  })
+
+  describe('$exists', () => {
+    it('compiles true to the jsonb key-exists operator', () => {
+      const [cond] = buildFilterConditions({ email: { $exists: true } })
+      const { sql, params } = render(cond)
+      expect(sql).toContain('?')
+      expect(sql).not.toMatch(/^NOT/i)
+      expect(params).toEqual(['email'])
+    })
+
+    it('compiles false to NOT key-exists', () => {
+      const [cond] = buildFilterConditions({ email: { $exists: false } })
+      expect(render(cond).sql).toMatch(/^NOT \(/i)
+    })
+
+    it('rejects non-boolean operands', () => {
+      expect(() => buildFilterConditions({ f: { $exists: 'yes' } })).toThrow(/boolean/)
+    })
+  })
+
+  describe('$contains', () => {
+    it('compiles to a string-guarded case-insensitive ILIKE', () => {
+      const [cond] = buildFilterConditions({ title: { $contains: 'widget' } })
+      const { sql, params } = render(cond)
+      expect(sql).toMatch(/jsonb_typeof\("records"\."data"->\$\d+\) = 'string'/)
+      expect(sql).toContain('ILIKE')
+      expect(params).toContain('%widget%')
+    })
+
+    it('escapes LIKE wildcards in the operand', () => {
+      const [cond] = buildFilterConditions({ title: { $contains: '50%_off\\now' } })
+      expect(render(cond).params).toContain('%50\\%\\_off\\\\now%')
+    })
+
+    it('rejects non-string operands', () => {
+      expect(() => buildFilterConditions({ f: { $contains: 5 } })).toThrow(/string/)
+    })
+  })
+
+  it('rejects unknown $-operators with the supported list', () => {
+    expect(() => buildFilterConditions({ f: { $regex: 'x' } })).toThrow(/Unsupported filter operator '\$regex'/)
+  })
+})
+
+describe('queryRecords field projection', () => {
+  it('limits data to the requested top-level keys, keeping system columns', async () => {
+    selectLimit.mockReturnValue({ offset: selectOffset })
+    selectOffset.mockResolvedValue([
+      {
+        id: 1,
+        collectionId: 1,
+        status: 'active',
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-02'),
+        data: { title: 'A', url: 'https://a.test', secret: 'hide-me' },
+      },
+    ])
+
+    const result = await queryRecords({ collectionId: 1, fields: ['title', 'url'] })
+    expect('records' in result && result.records[0]).toEqual(expect.objectContaining({
+      id: 1,
+      status: 'active',
+      data: { title: 'A', url: 'https://a.test' },
+    }))
+  })
+
+  it('omits requested keys absent from a record instead of inserting undefined', async () => {
+    selectLimit.mockReturnValue({ offset: selectOffset })
+    selectOffset.mockResolvedValue([
+      { id: 1, data: { title: 'A' }, createdAt: new Date(), updatedAt: new Date() },
+    ])
+
+    const result = await queryRecords({ collectionId: 1, fields: ['title', 'missing'] })
+    const record = ('records' in result ? result.records[0] : undefined) as { data: Record<string, unknown> }
+    expect(record.data).toEqual({ title: 'A' })
+    expect('missing' in record.data).toBe(false)
+  })
+
+  it('returns full data when fields is omitted (existing behavior)', async () => {
+    selectLimit.mockReturnValue({ offset: selectOffset })
+    selectOffset.mockResolvedValue([
+      { id: 1, data: { a: 1, b: 2 }, createdAt: new Date(), updatedAt: new Date() },
+    ])
+
+    const result = await queryRecords({ collectionId: 1 })
+    expect('records' in result && result.records[0].data).toEqual({ a: 1, b: 2 })
+  })
+})
+
 describe('queryRecords aggregation', () => {
   it('routes through db.execute when groupBy is set', async () => {
     dbExecute.mockResolvedValue({ rows: [{ status: 'open', count: 3 }] })
@@ -131,5 +338,34 @@ describe('queryRecords aggregation', () => {
   it('rejects a groupBy field that sanitizes to empty', async () => {
     await expect(queryRecords({ collectionId: 1, groupBy: '!!!' }))
       .rejects.toThrow(/Invalid field name/)
+  })
+
+  describe('sum and avg', () => {
+    async function aggregationSql(aggregate: Record<string, Record<string, string>>): Promise<string> {
+      dbExecute.mockResolvedValue({ rows: [] })
+      await queryRecords({ collectionId: 1, aggregate })
+      return render(dbExecute.mock.calls[0][0]).sql
+    }
+
+    it('sum aggregates only numeric values via a jsonb_typeof guard', async () => {
+      const sql = await aggregationSql({ revenue: { sum: 'amount' } })
+      expect(sql).toContain(`sum(CASE WHEN jsonb_typeof(data->'amount') = 'number' THEN (data->>'amount')::numeric END) as "revenue"`)
+    })
+
+    it('avg aggregates only numeric values via a jsonb_typeof guard', async () => {
+      const sql = await aggregationSql({ mean: { avg: 'price' } })
+      expect(sql).toContain(`avg(CASE WHEN jsonb_typeof(data->'price') = 'number' THEN (data->>'price')::numeric END) as "mean"`)
+    })
+
+    it('sanitizes field and alias names in sum/avg specs', async () => {
+      const sql = await aggregationSql({ 'x"; DROP TABLE records--': { sum: "a'; --" } })
+      expect(sql).not.toContain('DROP TABLE')
+      expect(sql).not.toContain("'; --")
+    })
+
+    it('existing min/max/distinct specs are unchanged', async () => {
+      const sql = await aggregationSql({ latest: { max: 'created' } })
+      expect(sql).toContain(`max(data->>'created') as "latest"`)
+    })
   })
 })

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -217,6 +217,7 @@ export type QueryParams = {
   search?: string;
   searchFields?: string[];
   sort?: string;
+  fields?: string[];
   groupBy?: string;
   aggregate?: Record<string, string | Record<string, string>>;
   timeBucket?: string;
@@ -224,7 +225,108 @@ export type QueryParams = {
   createdBefore?: string;
   limit?: number;
   offset?: number;
+  /** Internal: raises the 1000-row limit ceiling (used by export). Not exposed via MCP. */
+  limitCap?: number;
 };
+
+export const FILTER_OPERATORS = ["$gt", "$gte", "$lt", "$lte", "$ne", "$in", "$nin", "$exists", "$contains"] as const;
+
+const COMPARISON_OPS: Record<string, string> = { $gt: ">", $gte: ">=", $lt: "<", $lte: "<=" };
+
+/**
+ * An operator spec is an object value whose keys ALL start with `$`
+ * (e.g. {"$gte": 10, "$lt": 100}). Anything else — plain values, arrays,
+ * nested objects, mixed keys — falls back to JSONB containment, which
+ * keeps existing filter call shapes byte-for-byte compatible.
+ */
+function isOperatorSpec(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  return keys.length > 0 && keys.every((k) => k.startsWith("$"));
+}
+
+/**
+ * Build WHERE conditions for a filter object. Plain (non-operator) pairs
+ * are collected into a single JSONB containment condition, exactly as
+ * before; operator pairs each compile to a guarded, fully parameterized
+ * comparison. Numeric comparisons only apply where
+ * jsonb_typeof(data->field) = 'number' so mixed-type fields can't raise
+ * cast errors; string operands compare lexicographically as text (which
+ * also works for ISO-8601 date strings).
+ */
+export function buildFilterConditions(filter: Record<string, unknown>): SQL[] {
+  const conditions: SQL[] = [];
+  const containment: Record<string, unknown> = {};
+
+  for (const [field, value] of Object.entries(filter)) {
+    if (isOperatorSpec(value)) {
+      for (const [op, operand] of Object.entries(value)) {
+        conditions.push(buildOperatorCondition(field, op, operand));
+      }
+    } else {
+      containment[field] = value;
+    }
+  }
+
+  if (Object.keys(containment).length > 0) {
+    conditions.unshift(sql`${records.data} @> ${JSON.stringify(containment)}::jsonb`);
+  }
+
+  return conditions;
+}
+
+function buildOperatorCondition(field: string, op: string, operand: unknown): SQL {
+  if (op in COMPARISON_OPS) {
+    const cmp = sql.raw(COMPARISON_OPS[op]);
+    if (typeof operand === "number") {
+      return sql`(jsonb_typeof(${records.data}->${field}) = 'number' AND (${records.data}->>${field})::numeric ${cmp} ${operand})`;
+    }
+    if (typeof operand === "string") {
+      return sql`(jsonb_typeof(${records.data}->${field}) = 'string' AND (${records.data}->>${field}) ${cmp} ${operand})`;
+    }
+    throw new Error(`${op} requires a number or string operand`);
+  }
+
+  switch (op) {
+    case "$ne":
+      // Mongo semantics: matches records where the field differs OR is absent.
+      return sql`NOT (${records.data} @> ${JSON.stringify({ [field]: operand })}::jsonb)`;
+    case "$in":
+    case "$nin": {
+      if (!Array.isArray(operand)) throw new Error(`${op} requires an array operand`);
+      if (operand.length === 0) {
+        // $in [] matches nothing; $nin [] matches everything.
+        return op === "$in" ? sql`false` : sql`true`;
+      }
+      const list = sql.join(operand.map((v) => sql`${JSON.stringify(v)}::jsonb`), sql`, `);
+      const inCondition = sql`${records.data}->${field} = ANY(ARRAY[${list}])`;
+      return op === "$in"
+        ? inCondition
+        : sql`(${records.data}->${field} IS NULL OR NOT (${inCondition}))`;
+    }
+    case "$exists":
+      if (typeof operand !== "boolean") throw new Error("$exists requires a boolean operand");
+      return operand ? sql`${records.data} ? ${field}` : sql`NOT (${records.data} ? ${field})`;
+    case "$contains": {
+      if (typeof operand !== "string") throw new Error("$contains requires a string operand");
+      const pattern = `%${operand.replace(/[\\%_]/g, (m) => `\\${m}`)}%`;
+      return sql`(jsonb_typeof(${records.data}->${field}) = 'string' AND (${records.data}->>${field}) ILIKE ${pattern})`;
+    }
+    default:
+      throw new Error(`Unsupported filter operator '${op}'. Supported: ${FILTER_OPERATORS.join(", ")}`);
+  }
+}
+
+/** Keep only the requested top-level keys of a record's data (projection). */
+function projectData(data: unknown, fields: string[]): unknown {
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return data;
+  const source = data as Record<string, unknown>;
+  const projected: Record<string, unknown> = {};
+  for (const field of fields) {
+    if (field in source) projected[field] = source[field];
+  }
+  return projected;
+}
 
 export async function queryRecords(params: QueryParams) {
   const {
@@ -232,10 +334,12 @@ export async function queryRecords(params: QueryParams) {
     filter,
     search,
     sort,
+    fields,
     createdAfter,
     createdBefore,
     limit = 50,
     offset = 0,
+    limitCap = 1000,
     groupBy,
     aggregate,
     timeBucket,
@@ -244,7 +348,7 @@ export async function queryRecords(params: QueryParams) {
   const conditions: SQL[] = [eq(records.collectionId, collectionId), notDeleted];
 
   if (filter && Object.keys(filter).length > 0) {
-    conditions.push(sql`${records.data} @> ${JSON.stringify(filter)}::jsonb`);
+    conditions.push(...buildFilterConditions(filter));
   }
 
   if (search) {
@@ -290,7 +394,7 @@ export async function queryRecords(params: QueryParams) {
     orderBy = desc(records.createdAt);
   }
 
-  const clampedLimit = Math.min(Math.max(limit, 1), 1000);
+  const clampedLimit = Math.min(Math.max(limit, 1), limitCap);
 
   const selectQuery = db
     .select()
@@ -314,9 +418,13 @@ export async function queryRecords(params: QueryParams) {
     total = count;
   }
 
+  const projected = fields && fields.length > 0
+    ? results.map((r) => ({ ...r, data: projectData(r.data, fields) }))
+    : results;
+
   const hasMore = offset + results.length < total;
   return {
-    records: results,
+    records: projected,
     total,
     count: results.length,
     limit: clampedLimit,
@@ -374,6 +482,14 @@ async function queryWithAggregation(
             break;
           case "distinct":
             selectParts.push(`array_agg(distinct data->>'${safeField}') as "${safeAlias}"`);
+            break;
+          case "sum":
+            // Aggregate only numeric values (jsonb_typeof guard) so mixed-type
+            // fields can't raise cast errors; NULL when no numeric values exist.
+            selectParts.push(`sum(CASE WHEN jsonb_typeof(data->'${safeField}') = 'number' THEN (data->>'${safeField}')::numeric END) as "${safeAlias}"`);
+            break;
+          case "avg":
+            selectParts.push(`avg(CASE WHEN jsonb_typeof(data->'${safeField}') = 'number' THEN (data->>'${safeField}')::numeric END) as "${safeAlias}"`);
             break;
         }
       }

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -2,6 +2,8 @@ import { cache } from "react";
 import { db } from "./index";
 import { collections, records, collectionMembers, organizations, organizationMembers, user, type CollectionRole, type OrganizationRole } from "./schema";
 import { eq, and, sql, desc, asc, isNull, SQL } from "drizzle-orm";
+import { FIELD_NAME_RE } from "@/lib/constants";
+import { isPlainObject } from "@/lib/validation";
 
 export const notDeleted = isNull(records.deletedAt);
 
@@ -230,8 +232,12 @@ export type QueryParams = {
 };
 
 export const FILTER_OPERATORS = ["$gt", "$gte", "$lt", "$lte", "$ne", "$in", "$nin", "$exists", "$contains"] as const;
+export type FilterOperator = (typeof FILTER_OPERATORS)[number];
 
-const COMPARISON_OPS: Record<string, string> = { $gt: ">", $gte: ">=", $lt: "<", $lte: "<=" };
+type ComparisonOp = Extract<FilterOperator, "$gt" | "$gte" | "$lt" | "$lte">;
+const COMPARISON_OPS: Record<ComparisonOp, string> = { $gt: ">", $gte: ">=", $lt: "<", $lte: "<=" };
+
+const IN_ARRAY_LIMIT = 1000;
 
 /**
  * An operator spec is an object value whose keys ALL start with `$`
@@ -240,7 +246,7 @@ const COMPARISON_OPS: Record<string, string> = { $gt: ">", $gte: ">=", $lt: "<",
  * keeps existing filter call shapes byte-for-byte compatible.
  */
 function isOperatorSpec(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  if (!isPlainObject(value)) return false;
   const keys = Object.keys(value);
   return keys.length > 0 && keys.every((k) => k.startsWith("$"));
 }
@@ -276,8 +282,8 @@ export function buildFilterConditions(filter: Record<string, unknown>): SQL[] {
 }
 
 function buildOperatorCondition(field: string, op: string, operand: unknown): SQL {
-  if (op in COMPARISON_OPS) {
-    const cmp = sql.raw(COMPARISON_OPS[op]);
+  if (Object.hasOwn(COMPARISON_OPS, op)) {
+    const cmp = sql.raw(COMPARISON_OPS[op as ComparisonOp]);
     if (typeof operand === "number") {
       return sql`(jsonb_typeof(${records.data}->${field}) = 'number' AND (${records.data}->>${field})::numeric ${cmp} ${operand})`;
     }
@@ -294,6 +300,9 @@ function buildOperatorCondition(field: string, op: string, operand: unknown): SQ
     case "$in":
     case "$nin": {
       if (!Array.isArray(operand)) throw new Error(`${op} requires an array operand`);
+      if (operand.length > IN_ARRAY_LIMIT) {
+        throw new Error(`$in/$nin arrays are limited to ${IN_ARRAY_LIMIT} elements`);
+      }
       if (operand.length === 0) {
         // $in [] matches nothing; $nin [] matches everything.
         return op === "$in" ? sql`false` : sql`true`;
@@ -319,11 +328,10 @@ function buildOperatorCondition(field: string, op: string, operand: unknown): SQ
 
 /** Keep only the requested top-level keys of a record's data (projection). */
 function projectData(data: unknown, fields: string[]): unknown {
-  if (typeof data !== "object" || data === null || Array.isArray(data)) return data;
-  const source = data as Record<string, unknown>;
+  if (!isPlainObject(data)) return data;
   const projected: Record<string, unknown> = {};
   for (const field of fields) {
-    if (field in source) projected[field] = source[field];
+    if (Object.hasOwn(data, field)) projected[field] = data[field];
   }
   return projected;
 }
@@ -446,6 +454,8 @@ async function runCount(whereClause: SQL): Promise<number> {
   return count;
 }
 
+const AGGREGATION_OPS = "count, min, max, distinct, sum, avg";
+
 async function queryWithAggregation(
   whereClause: SQL,
   params: { groupBy?: string; aggregate?: Record<string, string | Record<string, string>>; timeBucket?: string; limit?: number }
@@ -467,31 +477,36 @@ async function queryWithAggregation(
 
   if (aggregate) {
     for (const [alias, spec] of Object.entries(aggregate)) {
-      if (spec === "count" || (typeof spec === "object" && "count" in spec)) {
+      if (spec === "count" || (isPlainObject(spec) && "count" in spec)) {
         selectParts.push(`count(*)::int as "${escapeField(alias)}"`);
-      } else if (typeof spec === "object") {
-        const [op, field] = Object.entries(spec)[0];
-        const safeField = escapeField(field);
-        const safeAlias = escapeField(alias);
-        switch (op) {
-          case "min":
-            selectParts.push(`min(data->>'${safeField}') as "${safeAlias}"`);
-            break;
-          case "max":
-            selectParts.push(`max(data->>'${safeField}') as "${safeAlias}"`);
-            break;
-          case "distinct":
-            selectParts.push(`array_agg(distinct data->>'${safeField}') as "${safeAlias}"`);
-            break;
-          case "sum":
-            // Aggregate only numeric values (jsonb_typeof guard) so mixed-type
-            // fields can't raise cast errors; NULL when no numeric values exist.
-            selectParts.push(`sum(CASE WHEN jsonb_typeof(data->'${safeField}') = 'number' THEN (data->>'${safeField}')::numeric END) as "${safeAlias}"`);
-            break;
-          case "avg":
-            selectParts.push(`avg(CASE WHEN jsonb_typeof(data->'${safeField}') = 'number' THEN (data->>'${safeField}')::numeric END) as "${safeAlias}"`);
-            break;
-        }
+        continue;
+      }
+      const specEntry = isPlainObject(spec) ? Object.entries(spec)[0] : undefined;
+      if (!specEntry) {
+        const label = typeof spec === "string" ? spec : JSON.stringify(spec);
+        throw new Error(`Unsupported aggregation '${label}'. Supported: ${AGGREGATION_OPS}`);
+      }
+      const [op, field] = specEntry;
+      const safeField = escapeField(field);
+      const safeAlias = escapeField(alias);
+      switch (op) {
+        case "min":
+          selectParts.push(`min(data->>'${safeField}') as "${safeAlias}"`);
+          break;
+        case "max":
+          selectParts.push(`max(data->>'${safeField}') as "${safeAlias}"`);
+          break;
+        case "distinct":
+          selectParts.push(`array_agg(distinct data->>'${safeField}') as "${safeAlias}"`);
+          break;
+        case "sum":
+        case "avg":
+          // Aggregate only numeric values (jsonb_typeof guard) so mixed-type
+          // fields can't raise cast errors; NULL when no numeric values exist.
+          selectParts.push(`${op}(CASE WHEN jsonb_typeof(data->'${safeField}') = 'number' THEN (data->>'${safeField}')::numeric END) as "${safeAlias}"`);
+          break;
+        default:
+          throw new Error(`Unsupported aggregation '${op}'. Supported: ${AGGREGATION_OPS}`);
       }
     }
   } else {
@@ -516,9 +531,10 @@ async function queryWithAggregation(
 }
 
 function escapeField(field: string): string {
-  const sanitized = field.replace(/[^a-zA-Z0-9_]/g, "");
-  if (!sanitized) throw new Error("Invalid field name");
-  return sanitized;
+  if (!FIELD_NAME_RE.test(field)) {
+    throw new Error(`Invalid field name '${field}' — only letters, numbers, and underscores are allowed`);
+  }
+  return field;
 }
 
 function escapeBucket(bucket: string): string {

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const { registeredTools } = vi.hoisted(() => ({
+const { registeredTools, registeredConfigs } = vi.hoisted(() => ({
   registeredTools: new Map<string, (params: unknown) => Promise<unknown>>(),
+  registeredConfigs: new Map<string, Record<string, unknown>>(),
 }))
 
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
   class McpServer {
-    registerTool(name: string, _config: unknown, handler: (params: unknown) => Promise<unknown>) {
+    registerTool(name: string, config: Record<string, unknown>, handler: (params: unknown) => Promise<unknown>) {
       registeredTools.set(name, handler)
+      registeredConfigs.set(name, config)
     }
   }
   return { McpServer }
@@ -49,6 +51,7 @@ vi.mock('@/lib/db', () => ({
 }))
 
 import { createMcpServer } from './server'
+import { FILTER_OPERATORS } from '@/lib/db/queries'
 import * as collectionService from '@/lib/services/collections'
 import * as recordService from '@/lib/services/records'
 import { createView } from '@/lib/services/views'
@@ -56,6 +59,7 @@ import { createView } from '@/lib/services/views'
 beforeEach(() => {
   vi.clearAllMocks()
   registeredTools.clear()
+  registeredConfigs.clear()
 })
 
 describe('createMcpServer tool registration', () => {
@@ -89,6 +93,27 @@ describe('createMcpServer tool registration', () => {
     ]
     for (const name of removed) {
       expect(registeredTools.has(name), `${name} should NOT be registered in Core`).toBe(false)
+    }
+  })
+})
+
+describe('tool input schemas and descriptions', () => {
+  it('caps import content at 10MB in the zod schema (mirrors the service-level cap)', () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    const schema = (registeredConfigs.get('hutch_import_records')!.inputSchema as {
+      content: { safeParse: (v: unknown) => { success: boolean } }
+    }).content
+    expect(schema.safeParse('a'.repeat(100)).success).toBe(true)
+    expect(schema.safeParse('a'.repeat(10 * 1024 * 1024 + 1)).success).toBe(false)
+  })
+
+  it('enumerates every FILTER_OPERATORS entry in the filter description', () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    const filter = (registeredConfigs.get('hutch_query_records')!.inputSchema as {
+      filter: { description?: string }
+    }).filter
+    for (const op of FILTER_OPERATORS) {
+      expect(filter.description, `expected filter description to mention ${op}`).toContain(op)
     }
   })
 })

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -22,6 +22,7 @@ vi.mock('@/lib/services/collections', () => ({
   deleteCollection: vi.fn(),
   inferCollectionSchema: vi.fn(),
   updateFieldDefinition: vi.fn(),
+  getCollectionStats: vi.fn(),
 }))
 
 vi.mock('@/lib/services/records', () => ({
@@ -33,6 +34,8 @@ vi.mock('@/lib/services/records', () => ({
   updateRecordStatus: vi.fn(),
   deleteRecord: vi.fn(),
   searchGlobal: vi.fn(),
+  exportRecords: vi.fn(),
+  importRecords: vi.fn(),
 }))
 
 vi.mock('@/lib/services/views', () => ({
@@ -63,6 +66,7 @@ describe('createMcpServer tool registration', () => {
       'hutch_store_records', 'hutch_query_records', 'hutch_search', 'hutch_update_collection',
       'hutch_delete_collection', 'hutch_delete_record', 'hutch_update_record', 'hutch_transform_records',
       'hutch_set_record_status', 'hutch_infer_schema', 'hutch_update_schema', 'hutch_create_view',
+      'hutch_collection_stats', 'hutch_export_records', 'hutch_import_records',
     ]
     for (const name of expected) {
       expect(registeredTools.has(name), `expected tool ${name} to be registered`).toBe(true)
@@ -145,6 +149,149 @@ describe('store_records tool', () => {
       summary: 'Saved 1 record to Users',
       action: 'created',
     }))
+  })
+})
+
+describe('query_records tool', () => {
+  it('forwards operator filters and the fields projection param to the service', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(recordService.queryRecords).mockResolvedValue({ records: [], total: 0 } as never)
+
+    await registeredTools.get('hutch_query_records')!({
+      slug: 'products',
+      filter: { price: { $gte: 10 }, status: 'active' },
+      fields: ['title', 'price'],
+    })
+
+    expect(recordService.queryRecords).toHaveBeenCalledWith('products', 'user-1', expect.objectContaining({
+      filter: { price: { $gte: 10 }, status: 'active' },
+      fields: ['title', 'price'],
+    }))
+  })
+})
+
+describe('collection_stats tool', () => {
+  it('returns the stats payload as JSON text', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(collectionService.getCollectionStats).mockResolvedValue({
+      name: 'Users',
+      slug: 'users',
+      record_count: 4,
+      by_status: { active: 4 },
+      first_created_at: '2026-01-01',
+      last_created_at: '2026-02-01',
+      first_updated_at: '2026-01-01',
+      last_updated_at: '2026-02-02',
+      approx_storage_bytes: 2048,
+      fields: [{ name: 'email', count: 4, percent: 100 }],
+    })
+
+    const result = await registeredTools.get('hutch_collection_stats')!({ slug: 'users' }) as { content: { text: string }[] }
+
+    expect(collectionService.getCollectionStats).toHaveBeenCalledWith('users', 'user-1')
+    expect(JSON.parse(result.content[0].text)).toEqual(expect.objectContaining({
+      record_count: 4,
+      by_status: { active: 4 },
+      approx_storage_bytes: 2048,
+      fields: [{ name: 'email', count: 4, percent: 100 }],
+    }))
+  })
+
+  it('returns isError when the collection is not found', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(collectionService.getCollectionStats).mockResolvedValue(null)
+
+    const result = await registeredTools.get('hutch_collection_stats')!({ slug: 'missing' }) as { isError?: boolean }
+    expect(result.isError).toBe(true)
+  })
+})
+
+describe('export_records tool', () => {
+  it('forwards format/filter/search/sort/fields/limit and returns metadata + content', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(recordService.exportRecords).mockResolvedValue({
+      collection: { name: 'Users', slug: 'users' },
+      format: 'csv',
+      count: 1,
+      total: 1,
+      truncated: false,
+      content: 'id,created_at,updated_at,name\r\n1,2026-01-01,2026-01-02,Alice\r\n',
+    } as never)
+
+    const result = await registeredTools.get('hutch_export_records')!({
+      collection: 'users',
+      format: 'csv',
+      filter: { active: true },
+      fields: ['name'],
+      limit: 5,
+    }) as { content: { text: string }[] }
+
+    expect(recordService.exportRecords).toHaveBeenCalledWith('users', 'user-1', expect.objectContaining({
+      format: 'csv',
+      filter: { active: true },
+      fields: ['name'],
+      limit: 5,
+    }))
+    expect(JSON.parse(result.content[0].text)).toEqual(expect.objectContaining({
+      format: 'csv',
+      count: 1,
+      truncated: false,
+      content: expect.stringContaining('id,created_at,updated_at,name'),
+    }))
+  })
+
+  it('returns isError when the collection is not found', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(recordService.exportRecords).mockResolvedValue(null)
+
+    const result = await registeredTools.get('hutch_export_records')!({ collection: 'missing' }) as { isError?: boolean }
+    expect(result.isError).toBe(true)
+  })
+})
+
+describe('import_records tool', () => {
+  it('forwards content and on_conflict, prepends the summary, and includes the collection url', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(recordService.importRecords).mockResolvedValue({
+      collection: { name: 'Users', slug: 'users' },
+      count: 2,
+      created: 2,
+      updated: 0,
+      skipped: 0,
+      summary: 'Saved 2 records to Users',
+    } as never)
+
+    const result = await registeredTools.get('hutch_import_records')!({
+      collection: 'users',
+      content: 'name\r\nAlice\r\nBob\r\n',
+      on_conflict: 'skip',
+    }) as { content: { text: string }[] }
+
+    expect(recordService.importRecords).toHaveBeenCalledWith('user-1', 'org-test', expect.objectContaining({
+      collection: 'users',
+      content: 'name\r\nAlice\r\nBob\r\n',
+      on_conflict: 'skip',
+    }))
+    const text = result.content[0].text
+    expect(text).toMatch(/^Saved 2 records to Users\n\n\{/)
+    const parsed = JSON.parse(text.slice(text.indexOf('{')))
+    expect(parsed).toEqual(expect.objectContaining({
+      count: 2,
+      created: 2,
+      url: 'https://example.test/c/users',
+    }))
+  })
+
+  it('returns isError when the service reports a parse error', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(recordService.importRecords).mockResolvedValue({ error: 'CSV content is empty — a header row is required', status: 400 } as never)
+
+    const result = await registeredTools.get('hutch_import_records')!({ collection: 'users', content: '' }) as {
+      isError?: boolean
+      content: { text: string }[]
+    }
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toMatch(/header row/)
   })
 })
 

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -5,6 +5,7 @@ import * as recordService from "@/lib/services/records";
 import * as fileService from "@/lib/services/files";
 import { createView } from "@/lib/services/views";
 import { VIEW_TYPES } from "@/lib/views/types";
+import { FILTER_OPERATORS } from "@/lib/db/queries";
 
 const SERVER_INSTRUCTIONS = `Hutch Core stores structured data for a single AI agent user. Records are arbitrary JSON, grouped into collections.
 
@@ -33,10 +34,10 @@ type McpToolResponse = { content: { type: "text"; text: string }[]; isError?: bo
 // filter param flows to the same query engine in both.
 const FILTER_DESCRIPTION =
   "Filter on record fields. Plain values are JSONB containment (exact) matches, e.g. {\"status\": \"active\"}. " +
-  "A field value that is an object whose keys all start with $ applies operators instead: " +
-  "$gt/$gte/$lt/$lte (number operands compare numerically, string operands — including ISO dates — compare lexicographically as text), " +
-  "$ne (not equal, also matches records missing the field), $in/$nin (array of values), $exists (boolean), " +
-  "$contains (case-insensitive substring match on string fields). " +
+  `A field value that is an object whose keys all start with $ applies operators instead: ${FILTER_OPERATORS.join(", ")}. ` +
+  "$gt/$gte/$lt/$lte compare (number operands numerically, string operands — including ISO dates — lexicographically as text); " +
+  "$ne is not-equal (also matches records missing the field); $in/$nin take an array of values; $exists takes a boolean; " +
+  "$contains is a case-insensitive substring match on string fields. " +
   "Example: {\"price\": {\"$gte\": 10, \"$lt\": 100}, \"status\": {\"$in\": [\"active\", \"pending\"]}}";
 
 function textResponse(text: string): McpToolResponse {
@@ -49,6 +50,18 @@ function errorResponse(text: string): McpToolResponse {
 
 function jsonResponse(value: unknown): McpToolResponse {
   return textResponse(JSON.stringify(value, null, 2));
+}
+
+/**
+ * Shared by hutch_store_records and hutch_import_records: attach the
+ * collection URL and lead with the human-readable summary when present.
+ */
+function summarizedWriteResponse(result: object, collectionUrl: (slug: string) => string): McpToolResponse {
+  const slug = (result as { collection?: { slug?: string } }).collection?.slug;
+  const enriched = slug ? { ...result, url: collectionUrl(slug) } : result;
+  const json = JSON.stringify(enriched, null, 2);
+  const summary = (result as { summary?: string }).summary;
+  return textResponse(summary ? `${summary}\n\n${json}` : json);
 }
 
 function collectionNotFound(slug: string): McpToolResponse {
@@ -131,11 +144,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
       if ('error' in result) {
         return errorResponse(result.error as string);
       }
-      const slug = (result as { collection?: { slug?: string } }).collection?.slug;
-      const enriched = slug ? { ...result, url: collectionUrl(slug) } : result;
-      const json = JSON.stringify(enriched, null, 2);
-      const summary = (result as { summary?: string }).summary;
-      return { content: [{ type: "text", text: summary ? `${summary}\n\n${json}` : json }] };
+      return summarizedWriteResponse(result, collectionUrl);
     }
   );
 
@@ -197,7 +206,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
   server.registerTool(
     "hutch_collection_stats",
     {
-      description: "Get statistics for one collection: record_count, counts by status, first/last created_at and updated_at, approximate storage bytes, and per-field fill rates (for each top-level key: how many records have it and what percent, most common first, capped at 50 keys). Example: use before a bulk cleanup, or when the user asks 'how complete is my contacts data?' or 'how big is this collection really?'.",
+      description: "Get statistics for one collection: record_count, counts by status, first/last created_at and updated_at, approximate storage bytes, and per-field fill rates (for each top-level key: how many records have it and what percent, most common first, capped at 50 keys). Fill rates are exact counts over all records (hutch_describe_collection's frequency is sampled). Example: use before a bulk cleanup, or when the user asks 'how complete is my contacts data?' or 'how big is this collection really?'.",
       inputSchema: { slug: z.string().describe("Collection slug") },
       annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     },
@@ -211,7 +220,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
   server.registerTool(
     "hutch_export_records",
     {
-      description: "Export a collection's records as JSON or CSV text. Accepts the same filter/search/sort/fields params as hutch_query_records, plus limit (default 1000, max 10000). Returns count, total, a truncated flag, and the serialized content. CSV columns are id, created_at, updated_at, then the union of top-level record fields; nested objects/arrays are JSON-stringified into their cell. Example: use when the user says 'give me my contacts as a CSV' or when handing data to a tool that wants a flat file.",
+      description: "Export a collection's records as JSON or CSV text. Accepts the same filter/search/sort/fields params as hutch_query_records, plus limit (default 1000, max 10000). Returns count, total, a truncated flag, and the serialized content. CSV columns are id, created_at, updated_at, then the union of top-level record fields; nested objects/arrays are JSON-stringified into their cell. CSV cells are written verbatim (no spreadsheet formula-escaping) so exports round-trip. Example: use when the user says 'give me my contacts as a CSV' or when handing data to a tool that wants a flat file.",
       inputSchema: {
         collection: z.string().describe("Collection slug"),
         format: z.enum(["json", "csv"]).optional().describe("Output format. Default: json"),
@@ -245,7 +254,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
       inputSchema: {
         collection: z.string().describe("Collection name or slug (created automatically if new)"),
         format: z.enum(["csv", "json"]).optional().describe("Content format. Default: csv"),
-        content: z.string().describe("Raw CSV text (header row required) or a JSON array of objects"),
+        content: z.string().max(10 * 1024 * 1024).describe("Raw CSV text (header row required) or a JSON array of objects. Max 10MB."),
         on_conflict: z.enum(["replace", "merge", "skip", "error"]).optional().describe("What to do when a record matches an existing unique key. Default: replace"),
       },
       annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
@@ -258,11 +267,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
         on_conflict: params.on_conflict,
       });
       if ('error' in result) return errorResponse(result.error as string);
-      const slug = (result as { collection?: { slug?: string } }).collection?.slug;
-      const enriched = slug ? { ...result, url: collectionUrl(slug) } : result;
-      const json = JSON.stringify(enriched, null, 2);
-      const summary = (result as { summary?: string }).summary;
-      return { content: [{ type: "text", text: summary ? `${summary}\n\n${json}` : json }] };
+      return summarizedWriteResponse(result, collectionUrl);
     }
   );
 

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -15,7 +15,9 @@ Workflow for answering questions about stored data:
 
 Collections auto-create on the first hutch_store_records. No setup step.
 
-Use filter for exact/numeric/enum matches, search for free-text across string fields, or combine both. Run hutch_describe_collection first when you don't know a field's type.
+Use filter for exact/numeric/enum matches, search for free-text across string fields, or combine both. Run hutch_describe_collection first when you don't know a field's type. Filters also accept Mongo-style operator objects per field: $gt, $gte, $lt, $lte, $ne, $in, $nin, $exists, $contains (e.g. {"price": {"$gte": 10}}).
+
+Use hutch_collection_stats for a quick overview of a collection's size and field coverage, and hutch_export_records / hutch_import_records to move data in and out as CSV or JSON.
 
 For deduplication: set unique_key via hutch_update_collection, then hutch_store_records honors on_conflict (default: replace).
 
@@ -26,6 +28,16 @@ Files: hutch_put_file stores a file at a path inside a collection (auto-created 
 This is the headless single-user Core. Multi-user sharing, organizations, invitations, and published dashboards live in Hutch Cloud (app.hutchdb.com), not here.`;
 
 type McpToolResponse = { content: { type: "text"; text: string }[]; isError?: boolean };
+
+// Shared between hutch_query_records and hutch_export_records — the same
+// filter param flows to the same query engine in both.
+const FILTER_DESCRIPTION =
+  "Filter on record fields. Plain values are JSONB containment (exact) matches, e.g. {\"status\": \"active\"}. " +
+  "A field value that is an object whose keys all start with $ applies operators instead: " +
+  "$gt/$gte/$lt/$lte (number operands compare numerically, string operands — including ISO dates — compare lexicographically as text), " +
+  "$ne (not equal, also matches records missing the field), $in/$nin (array of values), $exists (boolean), " +
+  "$contains (case-insensitive substring match on string fields). " +
+  "Example: {\"price\": {\"$gte\": 10, \"$lt\": 100}, \"status\": {\"$in\": [\"active\", \"pending\"]}}";
 
 function textResponse(text: string): McpToolResponse {
   return { content: [{ type: "text", text }] };
@@ -133,11 +145,12 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
       description: "Fetch records from a collection with filter, search, sort, group_by, aggregate, time_bucket, and pagination. Example: use when the user asks 'show me bookmarks tagged work from last week'.",
       inputSchema: {
         slug: z.string().describe("Collection slug"),
-        filter: z.record(z.string(), z.unknown()).optional().describe("JSONB containment filter (e.g. {\"status\": \"active\"}). Use for exact/numeric/enum matches."),
+        filter: z.record(z.string(), z.unknown()).optional().describe(FILTER_DESCRIPTION),
         search: z.string().optional().describe("Full-text search query. Use for free-text across string fields."),
         sort: z.string().optional().describe("Sort field, prefix with - for descending (e.g. \"-created_at\")"),
+        fields: z.array(z.string()).optional().describe("Projection: top-level data keys to include in each returned record's data (e.g. [\"title\", \"url\"]). System fields id/status/created_at/updated_at are always returned."),
         group_by: z.string().optional().describe("Field to group by for aggregation (e.g. \"status\")"),
-        aggregate: z.record(z.string(), z.unknown()).optional().describe("Aggregation spec mapping result alias to \"count\" or {op: field} where op is min/max/distinct (e.g. {\"total\": \"count\", \"latest\": {\"max\": \"created_at\"}})"),
+        aggregate: z.record(z.string(), z.unknown()).optional().describe("Aggregation spec mapping result alias to \"count\" or {op: field} where op is min/max/distinct/sum/avg (e.g. {\"total\": \"count\", \"revenue\": {\"sum\": \"amount\"}}). sum/avg only aggregate numeric values and return null when a field has none."),
         time_bucket: z.string().optional().describe("Time bucket (hour, day, week, month, year)"),
         created_after: z.string().optional().describe("Filter records created after this ISO date (e.g. \"2026-07-01\" or \"2026-07-01T12:00:00Z\")"),
         created_before: z.string().optional().describe("Filter records created before this ISO date (e.g. \"2026-07-18\")"),
@@ -151,6 +164,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
         filter: params.filter as Record<string, unknown> | undefined,
         search: params.search,
         sort: params.sort,
+        fields: params.fields,
         groupBy: params.group_by,
         aggregate: params.aggregate as Record<string, string | Record<string, string>> | undefined,
         timeBucket: params.time_bucket,
@@ -177,6 +191,78 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     async (params) => {
       const result = await recordService.searchGlobal(userId, params.search, params.limit);
       return jsonResponse(result);
+    }
+  );
+
+  server.registerTool(
+    "hutch_collection_stats",
+    {
+      description: "Get statistics for one collection: record_count, counts by status, first/last created_at and updated_at, approximate storage bytes, and per-field fill rates (for each top-level key: how many records have it and what percent, most common first, capped at 50 keys). Example: use before a bulk cleanup, or when the user asks 'how complete is my contacts data?' or 'how big is this collection really?'.",
+      inputSchema: { slug: z.string().describe("Collection slug") },
+      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
+    },
+    async ({ slug }) => {
+      const result = await collectionService.getCollectionStats(slug, userId);
+      if (!result) return collectionNotFound(slug);
+      return jsonResponse(result);
+    }
+  );
+
+  server.registerTool(
+    "hutch_export_records",
+    {
+      description: "Export a collection's records as JSON or CSV text. Accepts the same filter/search/sort/fields params as hutch_query_records, plus limit (default 1000, max 10000). Returns count, total, a truncated flag, and the serialized content. CSV columns are id, created_at, updated_at, then the union of top-level record fields; nested objects/arrays are JSON-stringified into their cell. Example: use when the user says 'give me my contacts as a CSV' or when handing data to a tool that wants a flat file.",
+      inputSchema: {
+        collection: z.string().describe("Collection slug"),
+        format: z.enum(["json", "csv"]).optional().describe("Output format. Default: json"),
+        filter: z.record(z.string(), z.unknown()).optional().describe(FILTER_DESCRIPTION),
+        search: z.string().optional().describe("Full-text search query applied before export"),
+        sort: z.string().optional().describe("Sort field, prefix with - for descending (e.g. \"-created_at\")"),
+        fields: z.array(z.string()).optional().describe("Top-level data keys to include (CSV data columns / JSON data keys). Omit for all fields."),
+        limit: z.number().optional().describe("Max records to export (default 1000, max 10000). Check the truncated flag in the response."),
+      },
+      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
+    },
+    async (params) => {
+      const result = await recordService.exportRecords(params.collection, userId, {
+        format: params.format,
+        filter: params.filter as Record<string, unknown> | undefined,
+        search: params.search,
+        sort: params.sort,
+        fields: params.fields,
+        limit: params.limit,
+      });
+      if (!result) return collectionNotFound(params.collection);
+      if ('error' in result) return errorResponse(result.error as string);
+      return jsonResponse(result);
+    }
+  );
+
+  server.registerTool(
+    "hutch_import_records",
+    {
+      description: "Import records into a collection from CSV or JSON text (auto-creates the collection if new; honors unique_key and on_conflict exactly like hutch_store_records). CSV requires a header row; numeric strings become numbers, true/false become booleans, empty cells are omitted, JSON-looking cells ({...} or [...]) are parsed, and id/created_at/updated_at columns are ignored — so hutch_export_records output round-trips cleanly. Example: use when the user pastes a spreadsheet export and says 'load this into Hutch'. For records you already hold as JSON objects, hutch_store_records is the more direct path.",
+      inputSchema: {
+        collection: z.string().describe("Collection name or slug (created automatically if new)"),
+        format: z.enum(["csv", "json"]).optional().describe("Content format. Default: csv"),
+        content: z.string().describe("Raw CSV text (header row required) or a JSON array of objects"),
+        on_conflict: z.enum(["replace", "merge", "skip", "error"]).optional().describe("What to do when a record matches an existing unique key. Default: replace"),
+      },
+      annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    },
+    async (params) => {
+      const result = await recordService.importRecords(userId, organizationId, {
+        collection: params.collection,
+        format: params.format,
+        content: params.content,
+        on_conflict: params.on_conflict,
+      });
+      if ('error' in result) return errorResponse(result.error as string);
+      const slug = (result as { collection?: { slug?: string } }).collection?.slug;
+      const enriched = slug ? { ...result, url: collectionUrl(slug) } : result;
+      const json = JSON.stringify(enriched, null, 2);
+      const summary = (result as { summary?: string }).summary;
+      return { content: [{ type: "text", text: summary ? `${summary}\n\n${json}` : json }] };
     }
   );
 

--- a/src/lib/services/collections.test.ts
+++ b/src/lib/services/collections.test.ts
@@ -80,6 +80,7 @@ import {
   addFieldOption,
   addFieldDefinition,
   describeCollection,
+  getCollectionStats,
 } from './collections'
 import { sortCollections } from '@/lib/collections/sort'
 import { findAccessibleCollectionBySlug, createCollectionWithOwner } from '@/lib/db/queries'
@@ -539,5 +540,94 @@ describe('sortCollections', () => {
     const before = input.slice()
     sortCollections(input, 'name', 'asc')
     expect(input).toEqual(before)
+  })
+})
+
+describe('getCollectionStats', () => {
+  function mockStatsQueries() {
+    // Order matches the Promise.all in getCollectionStats: summary, status, fields.
+    dbExecute
+      .mockResolvedValueOnce({
+        rows: [{
+          record_count: 4,
+          first_created_at: '2026-01-01 00:00:00+00',
+          last_created_at: '2026-02-01 00:00:00+00',
+          first_updated_at: '2026-01-01 00:00:00+00',
+          last_updated_at: '2026-02-02 00:00:00+00',
+          approx_storage_bytes: '2048', // pg returns bigint as string
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { status: 'active', count: 3 },
+          { status: 'archived', count: 1 },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { key: 'url', count: 4 },
+          { key: 'title', count: 3 },
+          { key: 'notes', count: 1 },
+        ],
+      })
+  }
+
+  it('returns null when the caller has no access', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue(undefined as never)
+    const result = await getCollectionStats('bookmarks', 'user-test')
+    expect(result).toBeNull()
+    expect(dbExecute).not.toHaveBeenCalled()
+  })
+
+  it('returns counts, timestamps, storage bytes, and per-field fill rates', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({ organization: mockOrg, collection: baseCollection, role: 'viewer' })
+    mockStatsQueries()
+
+    const result = await getCollectionStats('bookmarks', 'user-test')
+
+    expect(result).toEqual({
+      name: 'Bookmarks',
+      slug: 'bookmarks',
+      record_count: 4,
+      by_status: { active: 3, archived: 1 },
+      first_created_at: '2026-01-01 00:00:00+00',
+      last_created_at: '2026-02-01 00:00:00+00',
+      first_updated_at: '2026-01-01 00:00:00+00',
+      last_updated_at: '2026-02-02 00:00:00+00',
+      approx_storage_bytes: 2048,
+      fields: [
+        { name: 'url', count: 4, percent: 100 },
+        { name: 'title', count: 3, percent: 75 },
+        { name: 'notes', count: 1, percent: 25 },
+      ],
+    })
+  })
+
+  it('handles an empty collection without dividing by zero', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({ organization: mockOrg, collection: baseCollection, role: 'viewer' })
+    dbExecute
+      .mockResolvedValueOnce({
+        rows: [{
+          record_count: 0,
+          first_created_at: null,
+          last_created_at: null,
+          first_updated_at: null,
+          last_updated_at: null,
+          approx_storage_bytes: '0',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const result = await getCollectionStats('bookmarks', 'user-test')
+
+    expect(result).toEqual(expect.objectContaining({
+      record_count: 0,
+      by_status: {},
+      first_created_at: null,
+      last_created_at: null,
+      approx_storage_bytes: 0,
+      fields: [],
+    }))
   })
 })

--- a/src/lib/services/collections.ts
+++ b/src/lib/services/collections.ts
@@ -476,6 +476,79 @@ export async function addFieldOption(
   }
 }
 
+/** Cap on how many distinct top-level keys the fill-rate report returns. */
+const STATS_MAX_FIELDS = 50;
+
+/**
+ * Collection statistics: record count, counts by status, first/last
+ * created/updated timestamps, approximate storage bytes, and per-field
+ * fill rates for top-level keys (most common first, capped at 50).
+ */
+export async function getCollectionStats(slug: string, userId: string) {
+  const access = await findAccessibleCollectionBySlug(slug, userId, "viewer");
+  if (!access) return null;
+  const collection = access.collection;
+
+  const [summaryResult, statusResult, fieldResult] = await Promise.all([
+    db.execute(sql`
+      SELECT count(*)::int AS record_count,
+             min(created_at)::text AS first_created_at,
+             max(created_at)::text AS last_created_at,
+             min(updated_at)::text AS first_updated_at,
+             max(updated_at)::text AS last_updated_at,
+             coalesce(sum(pg_column_size(data)), 0)::bigint AS approx_storage_bytes
+      FROM records
+      WHERE collection_id = ${collection.id} AND deleted_at IS NULL`),
+    db.execute(sql`
+      SELECT status, count(*)::int AS count
+      FROM records
+      WHERE collection_id = ${collection.id} AND deleted_at IS NULL
+      GROUP BY status`),
+    db.execute(sql`
+      SELECT key, count(*)::int AS count
+      FROM records, LATERAL jsonb_object_keys(data) AS key
+      WHERE collection_id = ${collection.id} AND deleted_at IS NULL
+        AND jsonb_typeof(data) = 'object'
+      GROUP BY key
+      ORDER BY count DESC, key ASC
+      LIMIT ${STATS_MAX_FIELDS}`),
+  ]);
+
+  const summary = (summaryResult.rows[0] ?? {}) as {
+    record_count?: number;
+    first_created_at?: string | null;
+    last_created_at?: string | null;
+    first_updated_at?: string | null;
+    last_updated_at?: string | null;
+    approx_storage_bytes?: string | number | null;
+  };
+  const recordCount = summary.record_count ?? 0;
+
+  const byStatus: Record<string, number> = {};
+  for (const row of statusResult.rows as { status: string | null; count: number }[]) {
+    byStatus[row.status ?? "active"] = row.count;
+  }
+
+  const fields = (fieldResult.rows as { key: string; count: number }[]).map((row) => ({
+    name: row.key,
+    count: row.count,
+    percent: recordCount > 0 ? Math.round((row.count / recordCount) * 1000) / 10 : 0,
+  }));
+
+  return {
+    name: collection.name,
+    slug: collection.slug,
+    record_count: recordCount,
+    by_status: byStatus,
+    first_created_at: summary.first_created_at ?? null,
+    last_created_at: summary.last_created_at ?? null,
+    first_updated_at: summary.first_updated_at ?? null,
+    last_updated_at: summary.last_updated_at ?? null,
+    approx_storage_bytes: Number(summary.approx_storage_bytes ?? 0),
+    fields,
+  };
+}
+
 export async function describeCollection(slug: string, userId: string) {
   const access = await findAccessibleCollectionBySlug(slug, userId, "viewer");
   if (!access) return null;

--- a/src/lib/services/collections.ts
+++ b/src/lib/services/collections.ts
@@ -7,7 +7,7 @@ import { describeCollection as describeCollectionFields } from "@/lib/describe";
 import { uniqueSlug } from "@/lib/slugify";
 import { revalidateDashboard } from "@/lib/revalidation";
 import { inferSchema, mergeSchema, CollectionSchema, FieldDefinition, isSelectableField, MAX_OPTION_VALUE_LENGTH, MAX_OPTIONS_PER_FIELD } from "@/lib/schema-inference";
-import { FIELD_NAME_RE, MAX_FIELD_NAME_LENGTH } from "@/lib/constants";
+import { DEFAULT_RECORD_STATUS, FIELD_NAME_RE, MAX_FIELD_NAME_LENGTH } from "@/lib/constants";
 import { validateTrimmedLength } from "@/lib/validation";
 import { seedAutoViews } from "./views";
 import { cleanupCollectionBlobs } from "./files";
@@ -526,7 +526,7 @@ export async function getCollectionStats(slug: string, userId: string) {
 
   const byStatus: Record<string, number> = {};
   for (const row of statusResult.rows as { status: string | null; count: number }[]) {
-    byStatus[row.status ?? "active"] = row.count;
+    byStatus[row.status ?? DEFAULT_RECORD_STATUS] = row.count;
   }
 
   const fields = (fieldResult.rows as { key: string; count: number }[]).map((row) => ({

--- a/src/lib/services/records.test.ts
+++ b/src/lib/services/records.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const { insertReturning, updateReturning, selectLimit, dbExecute, mockBeforeCreateRecord } = vi.hoisted(() => ({
-  insertReturning: vi.fn(),
-  updateReturning: vi.fn(),
-  selectLimit: vi.fn(),
-  dbExecute: vi.fn(),
-  mockBeforeCreateRecord: vi.fn(),
-}))
+const { insertReturning, insertValues, updateReturning, selectLimit, dbExecute, mockBeforeCreateRecord } = vi.hoisted(() => {
+  const insertReturning = vi.fn()
+  return {
+    insertReturning,
+    insertValues: vi.fn(() => ({ returning: insertReturning })),
+    updateReturning: vi.fn(),
+    selectLimit: vi.fn(),
+    dbExecute: vi.fn(),
+    mockBeforeCreateRecord: vi.fn(),
+  }
+})
 
 // Partial mock: replace the beforeCreateRecord hook so tests can make it
 // reject, but keep the module's other exports (notably the real
@@ -19,7 +23,7 @@ vi.mock('@/lib/quota', async (importOriginal) => ({
 vi.mock('@/lib/db', () => ({
   db: {
     insert: vi.fn(() => ({
-      values: vi.fn(() => ({ returning: insertReturning })),
+      values: insertValues,
     })),
     update: vi.fn(() => ({
       set: vi.fn(() => ({
@@ -84,6 +88,8 @@ import {
   transformRecords,
   updateRecordStatus,
   deleteRecord,
+  exportRecords,
+  importRecords,
 } from './records'
 import {
   findCollectionByNameInOrg,
@@ -557,5 +563,246 @@ describe('deleteRecord', () => {
     selectLimit.mockResolvedValue([{ id: 5 }])
     const result = await deleteRecord('users', 'user-test', 5)
     expect(result).toEqual({ deleted: true, id: 5 })
+  })
+})
+
+describe('exportRecords', () => {
+  const engineRows = [
+    {
+      id: 1,
+      collectionId: 1,
+      status: 'active',
+      source: 'api',
+      deletedAt: null,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+      data: { title: 'First', tags: ['a', 'b'] },
+    },
+    {
+      id: 2,
+      collectionId: 1,
+      status: 'active',
+      source: 'api',
+      deletedAt: null,
+      createdAt: new Date('2026-01-03T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-04T00:00:00.000Z'),
+      data: { title: 'Second' },
+    },
+  ]
+
+  function grantAccess() {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({
+      organization: mockOrg,
+      collection: baseCollection,
+      role: 'viewer',
+    })
+  }
+
+  it('returns null when the caller has no access to the collection', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue(undefined as never)
+    const result = await exportRecords('users', 'user-test', {})
+    expect(result).toBeNull()
+    expect(queryRecordsEngine).not.toHaveBeenCalled()
+  })
+
+  it('defaults to JSON with count/total/truncated metadata', async () => {
+    grantAccess()
+    vi.mocked(queryRecordsEngine).mockResolvedValue({
+      records: engineRows, total: 2, count: 2, limit: 1000, offset: 0, has_more: false, next_offset: null,
+    } as never)
+
+    const result = await exportRecords('users', 'user-test', {})
+
+    expect(result).toEqual(expect.objectContaining({
+      format: 'json',
+      count: 2,
+      total: 2,
+      truncated: false,
+      collection: { name: 'Users', slug: 'users' },
+    }))
+    const parsed = JSON.parse((result as { content: string }).content)
+    expect(parsed).toEqual([
+      { id: 1, created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-02T00:00:00.000Z', data: { title: 'First', tags: ['a', 'b'] } },
+      { id: 2, created_at: '2026-01-03T00:00:00.000Z', updated_at: '2026-01-04T00:00:00.000Z', data: { title: 'Second' } },
+    ])
+  })
+
+  it('serializes CSV with system columns first and nested values JSON-stringified', async () => {
+    grantAccess()
+    vi.mocked(queryRecordsEngine).mockResolvedValue({
+      records: engineRows, total: 2, count: 2, limit: 1000, offset: 0, has_more: false, next_offset: null,
+    } as never)
+
+    const result = await exportRecords('users', 'user-test', { format: 'csv' })
+
+    const content = (result as { content: string }).content
+    expect(content.startsWith('id,created_at,updated_at,title,tags\r\n')).toBe(true)
+    expect(content).toContain('1,2026-01-01T00:00:00.000Z,2026-01-02T00:00:00.000Z,First,"[""a"",""b""]"')
+  })
+
+  it('forwards filter/search/sort/fields to the engine and clamps limit to 10000', async () => {
+    grantAccess()
+    vi.mocked(queryRecordsEngine).mockResolvedValue({
+      records: [], total: 0, count: 0, limit: 10000, offset: 0, has_more: false, next_offset: null,
+    } as never)
+
+    await exportRecords('users', 'user-test', {
+      filter: { status: { $ne: 'archived' } },
+      search: 'foo',
+      sort: '-created_at',
+      fields: ['title'],
+      limit: 99999,
+    })
+
+    expect(queryRecordsEngine).toHaveBeenCalledWith(expect.objectContaining({
+      collectionId: baseCollection.id,
+      filter: { status: { $ne: 'archived' } },
+      search: 'foo',
+      sort: '-created_at',
+      fields: ['title'],
+      limit: 10000,
+      limitCap: 10000,
+    }))
+  })
+
+  it('defaults limit to 1000', async () => {
+    grantAccess()
+    vi.mocked(queryRecordsEngine).mockResolvedValue({
+      records: [], total: 0, count: 0, limit: 1000, offset: 0, has_more: false, next_offset: null,
+    } as never)
+
+    await exportRecords('users', 'user-test', {})
+    expect(queryRecordsEngine).toHaveBeenCalledWith(expect.objectContaining({ limit: 1000 }))
+  })
+
+  it('sets truncated=true when the query has more rows than the limit', async () => {
+    grantAccess()
+    vi.mocked(queryRecordsEngine).mockResolvedValue({
+      records: engineRows, total: 5000, count: 2, limit: 2, offset: 0, has_more: true, next_offset: 2,
+    } as never)
+
+    const result = await exportRecords('users', 'user-test', { limit: 2 })
+    expect(result).toEqual(expect.objectContaining({ count: 2, total: 5000, truncated: true }))
+  })
+})
+
+describe('importRecords', () => {
+  beforeEach(() => {
+    // createRecords path: collection exists, no unique key, batch insert.
+    vi.mocked(findCollectionByNameInOrg).mockResolvedValue(baseCollection)
+    insertReturning.mockResolvedValue([{ id: 1 }, { id: 2 }])
+  })
+
+  it('parses CSV (with type inference) and routes through createRecords', async () => {
+    const content = 'name,age,active\r\nAlice,30,true\r\nBob,forty,false\r\n'
+    const result = await importRecords('user-test', 'org-test', { collection: 'Users', content })
+
+    expect(insertValues).toHaveBeenCalledWith([
+      expect.objectContaining({ collectionId: 1, data: { name: 'Alice', age: 30, active: true } }),
+      expect.objectContaining({ collectionId: 1, data: { name: 'Bob', age: 'forty', active: false } }),
+    ])
+    expect(result).toEqual(expect.objectContaining({
+      collection: { name: 'Users', slug: 'users' },
+      count: 2,
+      created: 2,
+      updated: 0,
+      skipped: 0,
+      summary: 'Saved 2 records to Users',
+    }))
+  })
+
+  it('honors the quota hook via the shared createRecords path', async () => {
+    const { QuotaExceededError } = await import('@/lib/quota')
+    mockBeforeCreateRecord.mockRejectedValueOnce(new QuotaExceededError('quota exceeded'))
+
+    const result = await importRecords('user-test', 'org-test', {
+      collection: 'Users',
+      content: 'a\r\n1\r\n',
+    })
+    expect(result).toEqual(expect.objectContaining({ status: 413 }))
+  })
+
+  it('passes on_conflict through to createRecords upsert handling', async () => {
+    vi.mocked(findCollectionByNameInOrg).mockResolvedValue({ ...baseCollection, uniqueKey: ['name'] })
+    selectLimit.mockResolvedValue([{ id: 7, data: { name: 'Alice', age: 1 } }])
+
+    const result = await importRecords('user-test', 'org-test', {
+      collection: 'Users',
+      content: 'name,age\r\nAlice,30\r\n',
+      on_conflict: 'skip',
+    })
+
+    expect(result).toEqual(expect.objectContaining({ count: 1, created: 0, updated: 0, skipped: 1 }))
+  })
+
+  it('returns 400 for CSV without a header row', async () => {
+    const result = await importRecords('user-test', 'org-test', { collection: 'Users', content: '' })
+    expect(result).toEqual(expect.objectContaining({ status: 400 }))
+  })
+
+  it('accepts a JSON array of objects', async () => {
+    const result = await importRecords('user-test', 'org-test', {
+      collection: 'Users',
+      format: 'json',
+      content: JSON.stringify([{ name: 'Alice' }, { name: 'Bob' }]),
+    })
+
+    expect(insertValues).toHaveBeenCalledWith([
+      expect.objectContaining({ data: { name: 'Alice' } }),
+      expect.objectContaining({ data: { name: 'Bob' } }),
+    ])
+    expect(result).toEqual(expect.objectContaining({ count: 2 }))
+  })
+
+  it('unwraps hutch_export_records JSON output so exports round-trip', async () => {
+    insertReturning.mockResolvedValue([{ id: 1 }])
+    const exported = JSON.stringify([
+      { id: 9, created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-02T00:00:00.000Z', data: { title: 'Hello' } },
+    ])
+
+    await importRecords('user-test', 'org-test', { collection: 'Users', format: 'json', content: exported })
+
+    expect(insertValues).toHaveBeenCalledWith([
+      expect.objectContaining({ data: { title: 'Hello' } }),
+    ])
+  })
+
+  it('returns 400 for invalid JSON content', async () => {
+    const result = await importRecords('user-test', 'org-test', {
+      collection: 'Users',
+      format: 'json',
+      content: 'not json',
+    })
+    expect(result).toEqual(expect.objectContaining({ status: 400 }))
+  })
+
+  it('CSV export content round-trips through CSV import', async () => {
+    // Export side
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({
+      organization: mockOrg, collection: baseCollection, role: 'viewer',
+    })
+    vi.mocked(queryRecordsEngine).mockResolvedValue({
+      records: [{
+        id: 3,
+        createdAt: new Date('2026-02-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-02-02T00:00:00.000Z'),
+        data: { title: 'Widget, "deluxe"', price: 19.99, in_stock: true, meta: { color: 'red' }, notes: 'a\nb' },
+      }],
+      total: 1, count: 1, limit: 1000, offset: 0, has_more: false, next_offset: null,
+    } as never)
+    const exported = await exportRecords('users', 'user-test', { format: 'csv' })
+
+    // Import side
+    insertReturning.mockResolvedValue([{ id: 4 }])
+    await importRecords('user-test', 'org-test', {
+      collection: 'Users',
+      content: (exported as { content: string }).content,
+    })
+
+    expect(insertValues).toHaveBeenCalledWith([
+      expect.objectContaining({
+        data: { title: 'Widget, "deluxe"', price: 19.99, in_stock: true, meta: { color: 'red' }, notes: 'a\nb' },
+      }),
+    ])
   })
 })

--- a/src/lib/services/records.test.ts
+++ b/src/lib/services/records.test.ts
@@ -620,11 +620,14 @@ describe('exportRecords', () => {
       truncated: false,
       collection: { name: 'Users', slug: 'users' },
     }))
-    const parsed = JSON.parse((result as { content: string }).content)
+    const content = (result as { content: string }).content
+    const parsed = JSON.parse(content)
     expect(parsed).toEqual([
       { id: 1, created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-02T00:00:00.000Z', data: { title: 'First', tags: ['a', 'b'] } },
       { id: 2, created_at: '2026-01-03T00:00:00.000Z', updated_at: '2026-01-04T00:00:00.000Z', data: { title: 'Second' } },
     ])
+    // Machine round-trip data: serialized compact, not pretty-printed.
+    expect(content).toBe(JSON.stringify(parsed))
   })
 
   it('serializes CSV with system columns first and nested values JSON-stringified', async () => {
@@ -765,6 +768,26 @@ describe('importRecords', () => {
     expect(insertValues).toHaveBeenCalledWith([
       expect.objectContaining({ data: { title: 'Hello' } }),
     ])
+  })
+
+  it('returns 400 when content exceeds the 10MB limit before parsing', async () => {
+    const result = await importRecords('user-test', 'org-test', {
+      collection: 'Users',
+      content: 'a'.repeat(10 * 1024 * 1024 + 1),
+    })
+    expect(result).toEqual({ error: 'Import content exceeds 10MB limit', status: 400 })
+    expect(insertValues).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when the parsed content exceeds 10000 records', async () => {
+    const content = JSON.stringify(Array.from({ length: 10001 }, (_, i) => ({ n: i })))
+    const result = await importRecords('user-test', 'org-test', {
+      collection: 'Users',
+      format: 'json',
+      content,
+    })
+    expect(result).toEqual({ error: 'Import is limited to 10000 records per call', status: 400 })
+    expect(insertValues).not.toHaveBeenCalled()
   })
 
   it('returns 400 for invalid JSON content', async () => {

--- a/src/lib/services/records.ts
+++ b/src/lib/services/records.ts
@@ -8,6 +8,7 @@ import { inferSchema, mergeSchema, detectNewFields, inferSchemaFromData, Collect
 import { seedAutoViews } from "./views";
 import { beforeCreateRecord, QuotaExceededError } from "@/lib/quota";
 import { RECORD_STATUSES, REINFER_COOLDOWN_MS, MAX_RECORD_SIZE, FIELD_NAME_RE } from "@/lib/constants";
+import { recordsToCsv, csvToRecords, type ExportRow } from "@/lib/csv";
 
 async function reinferCollectionSchema(collectionId: number, existingSchema: CollectionSchema | null) {
   try {
@@ -269,6 +270,142 @@ export async function queryRecords(slug: string, userId: string, params: Omit<Qu
   if (!access) return null;
 
   return queryRecordsEngine({ ...params, collectionId: access.collection.id });
+}
+
+export const EXPORT_DEFAULT_LIMIT = 1000;
+export const EXPORT_MAX_LIMIT = 10000;
+
+function toIso(value: Date | string | null | undefined): string {
+  if (!value) return "";
+  return value instanceof Date ? value.toISOString() : String(value);
+}
+
+/**
+ * Export a collection's records as serialized JSON or CSV text. Honors the
+ * same filter/search/sort/fields params as queryRecords; limit defaults to
+ * 1000 and caps at 10000. Returns the content plus count/truncated metadata.
+ */
+export async function exportRecords(slug: string, userId: string, params: {
+  format?: "json" | "csv";
+  filter?: Record<string, unknown>;
+  search?: string;
+  sort?: string;
+  fields?: string[];
+  limit?: number;
+}) {
+  const access = await findAccessibleCollectionBySlug(slug, userId, "viewer");
+  if (!access) return null;
+
+  const format = params.format ?? "json";
+  const limit = Math.min(Math.max(params.limit ?? EXPORT_DEFAULT_LIMIT, 1), EXPORT_MAX_LIMIT);
+
+  const result = await queryRecordsEngine({
+    collectionId: access.collection.id,
+    filter: params.filter,
+    search: params.search,
+    sort: params.sort,
+    fields: params.fields,
+    limit,
+    limitCap: EXPORT_MAX_LIMIT,
+  });
+
+  if (!("records" in result)) {
+    return { error: "Export does not support aggregation queries", status: 400 };
+  }
+
+  const rows: ExportRow[] = result.records.map((r) => ({
+    id: r.id,
+    created_at: toIso(r.createdAt),
+    updated_at: toIso(r.updatedAt),
+    data: (typeof r.data === "object" && r.data !== null && !Array.isArray(r.data)
+      ? r.data
+      : {}) as Record<string, unknown>,
+  }));
+
+  const content = format === "csv" ? recordsToCsv(rows) : JSON.stringify(rows, null, 2);
+
+  return {
+    collection: { name: access.collection.name, slug: access.collection.slug },
+    format,
+    count: rows.length,
+    total: result.total,
+    truncated: result.has_more,
+    content,
+  };
+}
+
+/**
+ * Import records from CSV or JSON text. Parsing happens here; storage goes
+ * through createRecords so unique_key/on_conflict/quota logic is honored.
+ * The bulky per-record results array is summarized down to counts.
+ */
+export async function importRecords(userId: string, organizationId: string, params: {
+  collection: string;
+  format?: "csv" | "json";
+  content: string;
+  on_conflict?: string;
+}) {
+  const { collection, format = "csv", content, on_conflict } = params;
+
+  let recordsToStore: Record<string, unknown>[];
+
+  if (format === "json") {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      return { error: "Invalid JSON content", status: 400 };
+    }
+    const items = Array.isArray(parsed) ? parsed : [parsed];
+    if (!items.every((item) => typeof item === "object" && item !== null && !Array.isArray(item))) {
+      return { error: "JSON content must be an object or an array of objects", status: 400 };
+    }
+    // Unwrap hutch_export_records output ({id, created_at, updated_at, data})
+    // so exports round-trip without nesting the data under a `data` key.
+    recordsToStore = (items as Record<string, unknown>[]).map((item) =>
+      "id" in item && "created_at" in item && "updated_at" in item &&
+      typeof item.data === "object" && item.data !== null && !Array.isArray(item.data)
+        ? (item.data as Record<string, unknown>)
+        : item
+    );
+  } else {
+    const parsed = csvToRecords(content);
+    if ("error" in parsed) return { error: parsed.error, status: 400 };
+    recordsToStore = parsed.records;
+  }
+
+  if (recordsToStore.length === 0) {
+    return { error: "No records found in content", status: 400 };
+  }
+
+  const result = await createRecords(userId, organizationId, {
+    collection,
+    records: recordsToStore,
+    on_conflict,
+  });
+  if ("error" in result) return result;
+
+  // We always pass `records`, so createRecords took the bulk branch.
+  const bulk = result as {
+    collection: { name: string; slug: string };
+    results?: { action: string }[];
+    count?: number;
+    summary?: string;
+  };
+
+  const counts = { created: 0, updated: 0, skipped: 0 };
+  for (const r of bulk.results ?? []) {
+    if (r.action === "created") counts.created++;
+    else if (r.action === "updated") counts.updated++;
+    else if (r.action === "skipped") counts.skipped++;
+  }
+
+  return {
+    collection: bulk.collection,
+    count: bulk.count ?? 0,
+    ...counts,
+    summary: bulk.summary,
+  };
 }
 
 export async function searchGlobal(userId: string, search: string, limit: number = 10) {

--- a/src/lib/services/records.ts
+++ b/src/lib/services/records.ts
@@ -9,6 +9,7 @@ import { seedAutoViews } from "./views";
 import { beforeCreateRecord, QuotaExceededError } from "@/lib/quota";
 import { RECORD_STATUSES, REINFER_COOLDOWN_MS, MAX_RECORD_SIZE, FIELD_NAME_RE } from "@/lib/constants";
 import { recordsToCsv, csvToRecords, type ExportRow } from "@/lib/csv";
+import { isPlainObject } from "@/lib/validation";
 
 async function reinferCollectionSchema(collectionId: number, existingSchema: CollectionSchema | null) {
   try {
@@ -199,17 +200,22 @@ export async function createRecords(userId: string, organizationId: string, para
   };
 }
 
-function buildSaveSummary(
-  collectionName: string,
-  results: { action: string }[],
-  collectionWasCreated: boolean,
-): string {
+function tallyActions(results: { action: string }[]): { created: number; updated: number; skipped: number } {
   const counts = { created: 0, updated: 0, skipped: 0 };
   for (const r of results) {
     if (r.action === "created") counts.created++;
     else if (r.action === "updated") counts.updated++;
     else if (r.action === "skipped") counts.skipped++;
   }
+  return counts;
+}
+
+function buildSaveSummary(
+  collectionName: string,
+  results: { action: string }[],
+  collectionWasCreated: boolean,
+): string {
+  const counts = tallyActions(results);
   const total = counts.created + counts.updated + counts.skipped;
   const noun = total === 1 ? "record" : "records";
 
@@ -265,19 +271,20 @@ export async function listRecords(slug: string, userId: string, limit: number = 
   return { records: recs, total, limit: clampedLimit, offset };
 }
 
-export async function queryRecords(slug: string, userId: string, params: Omit<QueryParams, 'collectionId'>) {
+export async function queryRecords(slug: string, userId: string, params: Omit<QueryParams, 'collectionId' | 'limitCap'>) {
   const access = await findAccessibleCollectionBySlug(slug, userId, "viewer");
   if (!access) return null;
 
   return queryRecordsEngine({ ...params, collectionId: access.collection.id });
 }
 
-export const EXPORT_DEFAULT_LIMIT = 1000;
-export const EXPORT_MAX_LIMIT = 10000;
+const EXPORT_DEFAULT_LIMIT = 1000;
+const EXPORT_MAX_LIMIT = 10000;
+const IMPORT_MAX_CONTENT_BYTES = 10 * 1024 * 1024; // 10MB — mirrored by the MCP zod schema
+const EXPORT_MAX_CONTENT_BYTES = 50 * 1024 * 1024; // 50MB
 
-function toIso(value: Date | string | null | undefined): string {
-  if (!value) return "";
-  return value instanceof Date ? value.toISOString() : String(value);
+function toIso(value: Date | null): string {
+  return value ? value.toISOString() : "";
 }
 
 /**
@@ -309,6 +316,9 @@ export async function exportRecords(slug: string, userId: string, params: {
     limitCap: EXPORT_MAX_LIMIT,
   });
 
+  // Type-narrowing assertion: exportRecords never passes aggregation params,
+  // so the engine always returns the records shape. This narrows the union
+  // for TypeScript; it is not a supported input path.
   if (!("records" in result)) {
     return { error: "Export does not support aggregation queries", status: 400 };
   }
@@ -317,12 +327,14 @@ export async function exportRecords(slug: string, userId: string, params: {
     id: r.id,
     created_at: toIso(r.createdAt),
     updated_at: toIso(r.updatedAt),
-    data: (typeof r.data === "object" && r.data !== null && !Array.isArray(r.data)
-      ? r.data
-      : {}) as Record<string, unknown>,
+    data: isPlainObject(r.data) ? r.data : {},
   }));
 
-  const content = format === "csv" ? recordsToCsv(rows) : JSON.stringify(rows, null, 2);
+  const content = format === "csv" ? recordsToCsv(rows) : JSON.stringify(rows);
+
+  if (content.length > EXPORT_MAX_CONTENT_BYTES) {
+    return { error: "Export exceeds 50MB — narrow with filter, fields, or a lower limit", status: 400 };
+  }
 
   return {
     collection: { name: access.collection.name, slug: access.collection.slug },
@@ -347,6 +359,10 @@ export async function importRecords(userId: string, organizationId: string, para
 }) {
   const { collection, format = "csv", content, on_conflict } = params;
 
+  if (content.length > IMPORT_MAX_CONTENT_BYTES) {
+    return { error: "Import content exceeds 10MB limit", status: 400 };
+  }
+
   let recordsToStore: Record<string, unknown>[];
 
   if (format === "json") {
@@ -357,15 +373,14 @@ export async function importRecords(userId: string, organizationId: string, para
       return { error: "Invalid JSON content", status: 400 };
     }
     const items = Array.isArray(parsed) ? parsed : [parsed];
-    if (!items.every((item) => typeof item === "object" && item !== null && !Array.isArray(item))) {
+    if (!items.every(isPlainObject)) {
       return { error: "JSON content must be an object or an array of objects", status: 400 };
     }
     // Unwrap hutch_export_records output ({id, created_at, updated_at, data})
     // so exports round-trip without nesting the data under a `data` key.
-    recordsToStore = (items as Record<string, unknown>[]).map((item) =>
-      "id" in item && "created_at" in item && "updated_at" in item &&
-      typeof item.data === "object" && item.data !== null && !Array.isArray(item.data)
-        ? (item.data as Record<string, unknown>)
+    recordsToStore = items.map((item) =>
+      "id" in item && "created_at" in item && "updated_at" in item && isPlainObject(item.data)
+        ? item.data
         : item
     );
   } else {
@@ -378,6 +393,10 @@ export async function importRecords(userId: string, organizationId: string, para
     return { error: "No records found in content", status: 400 };
   }
 
+  if (recordsToStore.length > EXPORT_MAX_LIMIT) {
+    return { error: `Import is limited to ${EXPORT_MAX_LIMIT} records per call`, status: 400 };
+  }
+
   const result = await createRecords(userId, organizationId, {
     collection,
     records: recordsToStore,
@@ -385,7 +404,6 @@ export async function importRecords(userId: string, organizationId: string, para
   });
   if ("error" in result) return result;
 
-  // We always pass `records`, so createRecords took the bulk branch.
   const bulk = result as {
     collection: { name: string; slug: string };
     results?: { action: string }[];
@@ -393,12 +411,7 @@ export async function importRecords(userId: string, organizationId: string, para
     summary?: string;
   };
 
-  const counts = { created: 0, updated: 0, skipped: 0 };
-  for (const r of bulk.results ?? []) {
-    if (r.action === "created") counts.created++;
-    else if (r.action === "updated") counts.updated++;
-    else if (r.action === "skipped") counts.skipped++;
-  }
+  const counts = tallyActions(bulk.results ?? []);
 
   return {
     collection: bulk.collection,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,5 +1,10 @@
 export type ValidationError = { error: string; status: 400 };
 
+/** True for plain objects only — rejects null, arrays, and primitives. */
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
  * Validate that `value`, after trim, is non-empty and ≤ `max` characters.
  *


### PR DESCRIPTION
Adds three MCP feature sets inspired by a survey of PostgreSQL MCP servers:

## Query improvements
- Mongo-style filter operators in `hutch_query_records`: `$gt/$gte/$lt/$lte/$ne/$in/$nin/$exists/$contains`, fully parameterized, with `jsonb_typeof` guards so mixed-type fields can't raise cast errors. Plain values keep exact containment semantics (backwards compatible).
- `sum`/`avg` aggregations alongside count/min/max/distinct.
- `fields` projection param.

## New tools
- `hutch_collection_stats`: record count, status breakdown, first/last timestamps, storage bytes, exact per-field fill rates.
- `hutch_export_records`: JSON/CSV export with the query tool's filter/search/sort/fields params, limit up to 10k, truncation flag.
- `hutch_import_records`: CSV/JSON import routed through the existing createRecords path (unique_key/on_conflict/quota honored), 10MB/10k caps.

## Also
- Zero-dependency RFC 4180 CSV module (`src/lib/csv.ts`).
- Hardening from four-lens review: Object.hasOwn guards, aggregation spec validation, escapeField throws instead of stripping, $in clamp, export byte guard.
- README refresh and hutch-core → hutchdb rename references.

Tests: 407 passing (55 new), tsc clean, zero new dependencies.

https://claude.ai/code/session_011SVZ6PMLVWrqy2KddwXKED