### PR TITLE
Fix transform_records rename SQL, add empty-op guard, slim list_collections

### DIFF
--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -453,6 +453,24 @@ describe('list_collections tool', () => {
       expect.objectContaining({ name: 'Users', slug: 'users' }),
     ])
   })
+
+  it('omits each collection schema so large accounts get a summary, not a dump', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+    vi.mocked(collectionService.listCollections).mockResolvedValue([
+      {
+        id: 1, name: 'Users', slug: 'users', description: null, uniqueKey: [],
+        published: false, recordCount: 3, lastRecordAt: null, updatedAt: new Date('2026-01-01'),
+        schema: { fields: [{ name: 'huge', type: 'text' }], version: 9 },
+        role: 'owner', createdAt: new Date('2026-01-01'),
+      },
+    ] as never)
+
+    const result = await registeredTools.get('hutch_list_collections')!({}) as { content: { text: string }[] }
+    const [row] = JSON.parse(result.content[0].text)
+    expect(row).toEqual(expect.objectContaining({ slug: 'users', recordCount: 3 }))
+    expect(row).not.toHaveProperty('schema')
+    expect(row).not.toHaveProperty('role')
+  })
 })
 
 describe('collection url in mutation responses', () => {

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -82,13 +82,28 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     "hutch_list_collections",
     {
       title: "List Collections",
-      description: "List every collection the user has stored, with id, name, slug, and record count. Example: use when the user asks 'what data do I have in Hutch?'.",
+      description: "List every collection the user has stored, with id, name, slug, description, unique_key, and record count. Use hutch_describe_collection for a collection's fields and types. Example: use when the user asks 'what data do I have in Hutch?'.",
       inputSchema: {},
       annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     },
     async () => {
       const collections = await collectionService.listCollections(userId);
-      return jsonResponse(collections);
+      // Summary only — omitting each collection's full schema keeps this
+      // response small on accounts with many collections; per-collection
+      // detail lives in hutch_describe_collection / hutch_get_collection.
+      return jsonResponse(
+        collections.map((c) => ({
+          id: c.id,
+          name: c.name,
+          slug: c.slug,
+          description: c.description,
+          uniqueKey: c.uniqueKey,
+          published: c.published,
+          recordCount: c.recordCount,
+          lastRecordAt: c.lastRecordAt,
+          updatedAt: c.updatedAt,
+        }))
+      );
     }
   );
 

--- a/src/lib/services/records.test.ts
+++ b/src/lib/services/records.test.ts
@@ -522,6 +522,35 @@ describe('transformRecords', () => {
     const result = await transformRecords('users', 'user-test', { set_field: { field: 'bad-name', value: 1 } })
     expect(result).toEqual(expect.objectContaining({ status: 400 }))
   })
+
+  it('rejects a call with no operations instead of silently succeeding', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({ organization: mockOrg, collection: baseCollection, role: 'editor' })
+    const result = await transformRecords('users', 'user-test', {})
+    expect(result).toEqual(expect.objectContaining({
+      status: 400,
+      error: expect.stringContaining('No transform operation'),
+    }))
+    expect(dbExecute).not.toHaveBeenCalled()
+  })
+
+  it('casts rename bind params to ::text (jsonb -> and - are overloaded and reject untyped params)', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({ organization: mockOrg, collection: baseCollection, role: 'editor' })
+    dbExecute.mockResolvedValue({ rowCount: 2 })
+    const result = await transformRecords('users', 'user-test', { rename_fields: { note: 'comment' } })
+    expect(result).toEqual(expect.objectContaining({ transformed: true, updated: 2 }))
+    const renderedChunks = (dbExecute.mock.calls[0][0] as { queryChunks?: unknown[] }).queryChunks ?? []
+    const sqlText = JSON.stringify(renderedChunks)
+    expect(sqlText).toContain('::text')
+  })
+
+  it('returns a clean error (no SQL text) when the rename query fails', async () => {
+    vi.mocked(findAccessibleCollectionBySlug).mockResolvedValue({ organization: mockOrg, collection: baseCollection, role: 'editor' })
+    dbExecute.mockRejectedValue(new Error('Failed query: UPDATE records SET ...'))
+    const result = await transformRecords('users', 'user-test', { rename_fields: { note: 'comment' } })
+    expect(result).toEqual(expect.objectContaining({ status: 500 }))
+    expect((result as { error: string }).error).not.toContain('UPDATE')
+    expect((result as { error: string }).error).not.toContain('query')
+  })
 })
 
 describe('updateRecordStatus', () => {

--- a/src/lib/services/records.ts
+++ b/src/lib/services/records.ts
@@ -519,7 +519,26 @@ export async function transformRecords(slug: string, userId: string, params: {
   const collection = access.collection;
 
   const { remove_fields, rename_fields, set_field } = params;
+
+  const hasOperation =
+    (remove_fields && remove_fields.length > 0) ||
+    (rename_fields && Object.keys(rename_fields).length > 0) ||
+    set_field !== undefined;
+  if (!hasOperation) {
+    return {
+      error: "No transform operation provided — pass rename_fields, remove_fields, or set_field",
+      status: 400,
+    };
+  }
+
   let totalUpdated = 0;
+
+  // Database failures return this clean message instead of surfacing raw
+  // driver/SQL text through the MCP tool output.
+  const transformFailed = {
+    error: "Transform failed while updating records — check the field names and values and try again",
+    status: 500,
+  };
 
   if (remove_fields && remove_fields.length > 0) {
     for (const field of remove_fields) {
@@ -530,11 +549,16 @@ export async function transformRecords(slug: string, userId: string, params: {
     // Remove all fields in a single query using array subtraction
     // Field names are validated by FIELD_NAME_RE (alphanumeric + underscore only)
     const fieldsLiteral = `{${remove_fields.join(",")}}`;
-    const result = await db.execute(
-      sql`UPDATE records SET data = data - ${fieldsLiteral}::text[], updated_at = now()
-          WHERE collection_id = ${collection.id} AND deleted_at IS NULL`
-    );
-    totalUpdated += result.rowCount ?? 0;
+    try {
+      const result = await db.execute(
+        sql`UPDATE records SET data = data - ${fieldsLiteral}::text[], updated_at = now()
+            WHERE collection_id = ${collection.id} AND deleted_at IS NULL`
+      );
+      totalUpdated += result.rowCount ?? 0;
+    } catch (err) {
+      console.error(`transformRecords remove_fields failed for collection ${collection.id}`, err);
+      return transformFailed;
+    }
   }
 
   if (rename_fields && Object.keys(rename_fields).length > 0) {
@@ -542,15 +566,23 @@ export async function transformRecords(slug: string, userId: string, params: {
       if (!FIELD_NAME_RE.test(oldName) || !FIELD_NAME_RE.test(newName)) {
         return { error: "Invalid field name", status: 400 };
       }
-      const result = await db.execute(
-        sql`UPDATE records
-            SET data = (data || jsonb_build_object(${newName}, data->${oldName})) - ${oldName},
-                updated_at = now()
-            WHERE collection_id = ${collection.id}
-            AND data ? ${oldName}
-            AND deleted_at IS NULL`
-      );
-      totalUpdated += result.rowCount ?? 0;
+      // The ::text casts are load-bearing: `->` and `-` are overloaded on
+      // (jsonb, text) and (jsonb, integer), so an untyped bind param makes
+      // Postgres reject the statement as ambiguous.
+      try {
+        const result = await db.execute(
+          sql`UPDATE records
+              SET data = (data || jsonb_build_object(${newName}, data->${oldName}::text)) - ${oldName}::text,
+                  updated_at = now()
+              WHERE collection_id = ${collection.id}
+              AND data ? ${oldName}
+              AND deleted_at IS NULL`
+        );
+        totalUpdated += result.rowCount ?? 0;
+      } catch (err) {
+        console.error(`transformRecords rename_fields failed for collection ${collection.id}`, err);
+        return transformFailed;
+      }
     }
   }
 
@@ -560,26 +592,31 @@ export async function transformRecords(slug: string, userId: string, params: {
       return { error: "Invalid field name", status: 400 };
     }
     const overlay = JSON.stringify({ [field]: value });
-    let result;
-    if (filter && Object.keys(filter).length > 0) {
-      result = await db.execute(
-        sql`UPDATE records
-            SET data = data || ${overlay}::jsonb,
-                updated_at = now()
-            WHERE collection_id = ${collection.id}
-            AND data @> ${JSON.stringify(filter)}::jsonb
-            AND deleted_at IS NULL`
-      );
-    } else {
-      result = await db.execute(
-        sql`UPDATE records
-            SET data = data || ${overlay}::jsonb,
-                updated_at = now()
-            WHERE collection_id = ${collection.id}
-            AND deleted_at IS NULL`
-      );
+    try {
+      let result;
+      if (filter && Object.keys(filter).length > 0) {
+        result = await db.execute(
+          sql`UPDATE records
+              SET data = data || ${overlay}::jsonb,
+                  updated_at = now()
+              WHERE collection_id = ${collection.id}
+              AND data @> ${JSON.stringify(filter)}::jsonb
+              AND deleted_at IS NULL`
+        );
+      } else {
+        result = await db.execute(
+          sql`UPDATE records
+              SET data = data || ${overlay}::jsonb,
+                  updated_at = now()
+              WHERE collection_id = ${collection.id}
+              AND deleted_at IS NULL`
+        );
+      }
+      totalUpdated += result.rowCount ?? 0;
+    } catch (err) {
+      console.error(`transformRecords set_field failed for collection ${collection.id}`, err);
+      return transformFailed;
     }
-    totalUpdated += result.rowCount ?? 0;
   }
 
   // Re-infer schema if fields were added or renamed (skip for remove-only)


### PR DESCRIPTION
- rename_fields SQL failed in production: data->$n and data - $n are
  ambiguous for untyped bind params (jsonb,text vs jsonb,integer overloads);
  add ::text casts. Unit tests mock the DB so they never caught it — found
  by exercising the live server.
- transformRecords with no operations now returns a 400 with guidance
  instead of silently succeeding with updated: 0.
- DB failures in transform ops return a clean error instead of leaking raw
  driver/SQL text through MCP tool output.
- hutch_list_collections omits each collection's schema blob (74KB response
  on a populated account); describe_collection covers per-collection detail.

Claude-Session: https://claude.ai/code/session_011SVZ6PMLVWrqy2KddwXKED
