### PR TITLE
Real-Postgres integration tier, full-loop smoke, and MCP surface hardening

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,24 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: hutch
+          POSTGRES_PASSWORD: hutch
+          POSTGRES_DB: hutch_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      # Enables the *.integration.test.ts tier — real SQL against the
+      # service Postgres above. Unit tests ignore this var.
+      HUTCH_TEST_DATABASE_URL: postgresql://hutch:hutch@localhost:5432/hutch_test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,17 @@ npm run test:watch
 
 For features that change behavior, write failing tests against the agreed contract first, then implement to green. Tests live next to source as `*.test.ts(x)`.
 
+### Integration tests (real Postgres)
+
+Files matching `*.integration.test.ts` run generated SQL against a real scratch database — no mocks. They auto-skip when `HUTCH_TEST_DATABASE_URL` is unset, so plain `npm test` stays green with no infrastructure. To run them locally:
+
+```bash
+createdb hutch_test
+HUTCH_TEST_DATABASE_URL=postgresql://localhost/hutch_test npm test
+```
+
+Use a dedicated scratch database — the suite applies migrations to it and truncates tables between tests. Never point it at your development database. CI runs this tier automatically against a `postgres:16` service (see `.github/workflows/test.yml`).
+
 ## What's in scope
 
 Hutch is a personal-use structured data store for AI agents. Bug fixes, performance improvements, and small features that fit that purpose are welcome.

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -13,9 +13,16 @@
 // - In every case, 401 responses must NOT include a WWW-Authenticate header.
 //   Core has no OAuth authorization server; the presence of that header would
 //   suggest a stale build.
+//
+// Opt-in full loop (SMOKE_FULL=1): runs a real MCP session end to end —
+// initialize → tools/list (18 tools, titles, readOnlyHint on read tools) →
+// store → query (operator filter) → transform (rename) → export CSV →
+// delete collection — against a scratch collection that is removed at the
+// end. Requires the target server to have a working database.
 
 const BASE_URL = (process.env.SMOKE_BASE_URL ?? "http://localhost:3000").replace(/\/$/, "");
 const API_KEY = process.env.SMOKE_API_KEY;
+const SMOKE_FULL = process.env.SMOKE_FULL === "1";
 const MCP_URL = `${BASE_URL}/api/mcp`;
 
 const failures: string[] = [];
@@ -69,12 +76,189 @@ async function checkAnonymous() {
   if (res.status === 401) assertNoWwwAuthenticate(res, `${MCP_URL} (anon 401)`);
 }
 
+// ── SMOKE_FULL=1: full MCP tool-call loop ────────────────────────────────────
+
+type JsonRpcMessage = {
+  jsonrpc: string;
+  id?: number | string | null;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+};
+
+/**
+ * Parse a JSON-RPC response body that may arrive either as plain JSON or as
+ * an SSE stream (the streamable-HTTP transport picks per the Accept header —
+ * postMcp advertises both). For SSE, the payload is in `data:` lines; the
+ * response to our request is the event whose message carries an id.
+ */
+async function readJsonRpcResponse(res: Response): Promise<JsonRpcMessage> {
+  const contentType = res.headers.get("content-type") ?? "";
+  const text = await res.text();
+
+  if (contentType.includes("text/event-stream")) {
+    for (const line of text.split(/\r?\n/)) {
+      if (!line.startsWith("data:")) continue;
+      try {
+        const msg = JSON.parse(line.slice(5).trim()) as JsonRpcMessage;
+        if (msg.id !== undefined && msg.id !== null) return msg;
+      } catch {
+        // Non-JSON data line (keepalive etc.) — skip.
+      }
+    }
+    throw new Error(`SSE response contained no JSON-RPC message: ${text.slice(0, 200)}`);
+  }
+
+  return JSON.parse(text) as JsonRpcMessage;
+}
+
+let rpcId = 0;
+
+async function rpc(method: string, params?: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const res = await fetch(MCP_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...(API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {}),
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcId, method, ...(params ? { params } : {}) }),
+  });
+  if (res.status >= 400) {
+    throw new Error(`${method}: HTTP ${res.status}`);
+  }
+  const msg = await readJsonRpcResponse(res);
+  if (msg.error) {
+    throw new Error(`${method}: JSON-RPC error ${msg.error.code}: ${msg.error.message}`);
+  }
+  if (!msg.result) {
+    throw new Error(`${method}: response had no result`);
+  }
+  return msg.result;
+}
+
+type ToolCallResult = { content?: { type: string; text?: string }[]; isError?: boolean };
+
+/** tools/call, returning the first text content block (usually JSON). */
+async function callTool(name: string, args: Record<string, unknown>): Promise<string> {
+  const result = (await rpc("tools/call", { name, arguments: args })) as ToolCallResult;
+  const text = result.content?.find((c) => c.type === "text")?.text ?? "";
+  if (result.isError) {
+    throw new Error(`tools/call ${name}: tool error: ${text.slice(0, 300)}`);
+  }
+  return text;
+}
+
+/** Parse the JSON blob out of a tool response (some lead with a summary line). */
+function toolJson(text: string): Record<string, unknown> {
+  const start = text.search(/[[{]/);
+  if (start === -1) throw new Error(`tool response had no JSON: ${text.slice(0, 200)}`);
+  return JSON.parse(text.slice(start)) as Record<string, unknown>;
+}
+
+const EXPECTED_TOOL_COUNT = 18;
+
+// Tools registered with readOnlyHint: true in src/lib/mcp/server.ts.
+const READ_ONLY_TOOLS = [
+  "hutch_list_collections",
+  "hutch_get_collection",
+  "hutch_describe_collection",
+  "hutch_query_records",
+  "hutch_search",
+  "hutch_collection_stats",
+  "hutch_export_records",
+];
+
+async function checkFull() {
+  console.log("smoke: SMOKE_FULL=1 — running full MCP loop");
+
+  // initialize
+  const init = await rpc("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "hutch-smoke", version: "1.0.0" },
+  });
+  check(typeof init.protocolVersion === "string", "initialize: missing protocolVersion in result");
+
+  // tools/list — count, titles, read-only hints
+  const listed = await rpc("tools/list");
+  const tools = (listed.tools ?? []) as {
+    name: string;
+    title?: string;
+    annotations?: { readOnlyHint?: boolean };
+  }[];
+  check(
+    tools.length === EXPECTED_TOOL_COUNT,
+    `tools/list: expected exactly ${EXPECTED_TOOL_COUNT} tools, got ${tools.length}`,
+  );
+  for (const tool of tools) {
+    check(
+      typeof tool.title === "string" && tool.title.length > 0,
+      `tools/list: tool ${tool.name} has no title`,
+    );
+  }
+  const byName = new Map(tools.map((t) => [t.name, t]));
+  for (const name of READ_ONLY_TOOLS) {
+    const tool = byName.get(name);
+    check(tool !== undefined, `tools/list: read tool ${name} is missing`);
+    check(
+      tool?.annotations?.readOnlyHint === true,
+      `tools/list: read tool ${name} lacks readOnlyHint: true`,
+    );
+  }
+
+  // tools/call cycle against a scratch collection
+  const collectionName = `smoke_full_${Date.now()}`;
+  let slug: string | undefined;
+  try {
+    const stored = toolJson(
+      await callTool("hutch_store_records", {
+        collection: collectionName,
+        records: [
+          { item: "aa", n: 1 },
+          { item: "bb", n: 2 },
+          { item: "cc", n: 3 },
+        ],
+      }),
+    );
+    slug = (stored.collection as { slug?: string } | undefined)?.slug;
+    check(typeof slug === "string" && slug.length > 0, "store_records: no collection slug in response");
+    check(stored.count === 3, `store_records: expected count 3, got ${stored.count}`);
+    if (!slug) return;
+
+    const queried = toolJson(
+      await callTool("hutch_query_records", { slug, filter: { n: { $gte: 2 } } }),
+    );
+    check(queried.total === 2, `query_records ($gte operator): expected total 2, got ${queried.total}`);
+
+    const transformed = toolJson(
+      await callTool("hutch_transform_records", { slug, rename_fields: { n: "num" } }),
+    );
+    check(transformed.updated === 3, `transform_records rename: expected 3 updated, got ${transformed.updated}`);
+
+    const exported = toolJson(await callTool("hutch_export_records", { collection: slug, format: "csv" }));
+    check(exported.format === "csv", `export_records: expected csv format, got ${exported.format}`);
+    check(exported.count === 3, `export_records: expected count 3, got ${exported.count}`);
+    const csv = typeof exported.content === "string" ? exported.content : "";
+    const header = csv.split(/\r?\n/)[0].split(",");
+    check(header.includes("num"), "export_records: CSV missing renamed column 'num'");
+    check(!header.includes("n"), "export_records: CSV still has pre-rename column 'n'");
+  } finally {
+    // Always try to remove the scratch collection, even on assertion failure.
+    if (slug) {
+      const deleted = await callTool("hutch_delete_collection", { slug });
+      check(deleted.includes("deleted"), `delete_collection: unexpected response: ${deleted.slice(0, 120)}`);
+    }
+  }
+}
+
 async function main() {
   const mode = API_KEY ? "keyed" : "anonymous";
   console.log(`smoke: target ${BASE_URL} (${mode} mode)`);
 
   if (API_KEY) await checkKeyed();
   else await checkAnonymous();
+
+  if (SMOKE_FULL && failures.length === 0) await checkFull();
 
   if (failures.length > 0) {
     console.error(`\nsmoke: ${failures.length} failure(s)`);

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -107,6 +107,188 @@ describe('createMcpServer tool registration', () => {
   })
 })
 
+describe('tool surface snapshot', () => {
+  // Deliberate-drift gate for the connectors directory: any change to a tool
+  // name, title, safety annotations, or input keys must update this literal.
+  it('matches the pinned 18-tool connector surface exactly', () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+
+    const surface = [...registeredConfigs.entries()]
+      .map(([name, config]) => {
+        const annotations = (config.annotations ?? {}) as {
+          readOnlyHint?: boolean
+          destructiveHint?: boolean
+          idempotentHint?: boolean
+        }
+        return {
+          name,
+          title: config.title as string,
+          readOnlyHint: annotations.readOnlyHint,
+          destructiveHint: annotations.destructiveHint,
+          idempotentHint: annotations.idempotentHint,
+          inputKeys: Object.keys((config.inputSchema ?? {}) as Record<string, unknown>).sort(),
+        }
+      })
+      .sort((a, b) => a.name.localeCompare(b.name))
+
+    expect(surface).toEqual([
+      { name: 'hutch_collection_stats', title: 'Collection Stats', readOnlyHint: true, idempotentHint: true, inputKeys: ['slug'] },
+      { name: 'hutch_create_view', title: 'Create View', destructiveHint: false, idempotentHint: false, inputKeys: ['columns', 'config', 'filter', 'group_by', 'name', 'slug', 'sort', 'type'] },
+      { name: 'hutch_delete_collection', title: 'Delete Collection', destructiveHint: true, idempotentHint: true, inputKeys: ['slug'] },
+      { name: 'hutch_delete_record', title: 'Delete Record', destructiveHint: true, idempotentHint: true, inputKeys: ['record_id', 'slug'] },
+      { name: 'hutch_describe_collection', title: 'Describe Collection', readOnlyHint: true, idempotentHint: true, inputKeys: ['slug'] },
+      { name: 'hutch_export_records', title: 'Export Records', readOnlyHint: true, idempotentHint: true, inputKeys: ['collection', 'fields', 'filter', 'format', 'limit', 'search', 'sort'] },
+      { name: 'hutch_get_collection', title: 'Get Collection', readOnlyHint: true, idempotentHint: true, inputKeys: ['slug'] },
+      { name: 'hutch_import_records', title: 'Import Records', destructiveHint: false, idempotentHint: false, inputKeys: ['collection', 'content', 'format', 'on_conflict'] },
+      { name: 'hutch_infer_schema', title: 'Infer Schema', destructiveHint: true, idempotentHint: true, inputKeys: ['slug'] },
+      { name: 'hutch_list_collections', title: 'List Collections', readOnlyHint: true, idempotentHint: true, inputKeys: [] },
+      { name: 'hutch_query_records', title: 'Query Records', readOnlyHint: true, idempotentHint: true, inputKeys: ['aggregate', 'created_after', 'created_before', 'fields', 'filter', 'group_by', 'limit', 'offset', 'search', 'slug', 'sort', 'time_bucket'] },
+      { name: 'hutch_search', title: 'Search Records', readOnlyHint: true, idempotentHint: true, inputKeys: ['limit', 'search'] },
+      { name: 'hutch_set_record_status', title: 'Set Record Status', destructiveHint: true, idempotentHint: true, inputKeys: ['record_id', 'slug', 'status'] },
+      { name: 'hutch_store_records', title: 'Store Records', destructiveHint: false, idempotentHint: true, inputKeys: ['collection', 'data', 'on_conflict', 'records'] },
+      { name: 'hutch_transform_records', title: 'Transform Records', destructiveHint: true, idempotentHint: false, inputKeys: ['remove_fields', 'rename_fields', 'set_field', 'slug'] },
+      { name: 'hutch_update_collection', title: 'Update Collection', destructiveHint: true, idempotentHint: true, inputKeys: ['description', 'name', 'published', 'slug', 'unique_key'] },
+      { name: 'hutch_update_record', title: 'Update Record', destructiveHint: true, idempotentHint: true, inputKeys: ['data', 'record_id', 'slug'] },
+      { name: 'hutch_update_schema', title: 'Update Schema', destructiveHint: true, idempotentHint: true, inputKeys: ['field', 'hidden', 'options', 'position', 'slug', 'type'] },
+    ])
+  })
+})
+
+describe('error hygiene chokepoint', () => {
+  it('masks DrizzleQueryError-shaped failures with a generic database message and logs the real error', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+
+    // Mirror drizzle-orm 0.45's DrizzleQueryError: message leads with
+    // "Failed query: <sql>\nparams: <params>" (the class never assigns
+    // this.name, so the message prefix is the live signal).
+    const driverError = new Error(
+      'Failed query: UPDATE records SET data = $1 WHERE id = $2\nparams: {"secret":"hunter2"},42'
+    )
+    vi.mocked(recordService.queryRecords).mockRejectedValue(driverError)
+
+    const result = await registeredTools.get('hutch_query_records')!({ slug: 'users' }) as {
+      isError?: boolean
+      content: { text: string }[]
+    }
+
+    expect(result.isError).toBe(true)
+    const text = result.content[0].text
+    expect(text).toBe('hutch_query_records failed while accessing the database. Try again or adjust the inputs.')
+    // No driver internals leak into the client-visible text.
+    expect(text).not.toMatch(/UPDATE/)
+    expect(text).not.toMatch(/params/)
+    expect(text).not.toMatch(/query:/)
+    expect(text).not.toMatch(/hunter2/)
+    // The real error is still logged server-side for operators.
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('hutch_query_records'), driverError)
+    consoleError.mockRestore()
+  })
+
+  it('masks errors carrying the DrizzleQueryError name even without the message prefix', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+
+    const driverError = new Error('connection terminated unexpectedly')
+    driverError.name = 'DrizzleQueryError'
+    vi.mocked(collectionService.listCollections).mockRejectedValue(driverError)
+
+    const result = await registeredTools.get('hutch_list_collections')!({}) as {
+      isError?: boolean
+      content: { text: string }[]
+    }
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe('hutch_list_collections failed while accessing the database. Try again or adjust the inputs.')
+    consoleError.mockRestore()
+  })
+
+  it('rethrows non-database errors unchanged so validation messages reach the client via the SDK', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+
+    const validationError = new Error(
+      "Unsupported filter operator '$regex'. Supported: $gt, $gte, $lt, $lte, $ne, $in, $nin, $exists, $contains"
+    )
+    vi.mocked(recordService.queryRecords).mockRejectedValue(validationError)
+
+    // The SDK stringifies rethrown errors into the tool output verbatim, so
+    // asserting the wrapped handler rejects with the exact error matches
+    // what the client ends up seeing.
+    await expect(registeredTools.get('hutch_query_records')!({ slug: 'users', filter: { name: { $regex: 'x' } } }))
+      .rejects.toThrow("Unsupported filter operator '$regex'. Supported: $gt, $gte, $lt, $lte, $ne, $in, $nin, $exists, $contains")
+  })
+})
+
+describe('response size budgets', () => {
+  it('keeps hutch_list_collections under 48KB for 50 collections with long descriptions', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+
+    // 500-char descriptions on every collection — the worst realistic case
+    // for a busy account. Measured response: ~41,100 bytes (descriptions
+    // alone are 25,000, so a 32KB budget is not attainable at this fixture
+    // size); budget pinned at the next round bound, 48KB.
+    const longDescription = (i: number) =>
+      `Collection ${i}: `.padEnd(
+        500,
+        'Curated research links and notes gathered by the agent during long-running investigations, including source URLs, extraction timestamps, relevance scores, and reviewer annotations. '
+      )
+    vi.mocked(collectionService.listCollections).mockResolvedValue(
+      Array.from({ length: 50 }, (_, i) => ({
+        id: i + 1,
+        name: `Research Collection ${i + 1}`,
+        slug: `research-collection-${i + 1}`,
+        description: longDescription(i + 1),
+        uniqueKey: ['url', 'captured_at'],
+        published: i % 2 === 0,
+        recordCount: 12000 + i,
+        lastRecordAt: '2026-08-01T12:34:56.000Z',
+        updatedAt: '2026-08-02T01:23:45.000Z',
+      })) as never
+    )
+
+    const result = await registeredTools.get('hutch_list_collections')!({}) as { content: { text: string }[] }
+    const bytes = Buffer.byteLength(result.content[0].text, 'utf8')
+    expect(bytes).toBeLessThan(48 * 1024)
+    // Sanity: the fixture is actually big — a shrunken fixture would make
+    // the budget assertion meaningless.
+    expect(bytes).toBeGreaterThan(30 * 1024)
+  })
+
+  it('keeps a default hutch_query_records page under 128KB for 50 records of ~1KB data each', async () => {
+    createMcpServer('user-1', 'org-test', 'https://example.test')
+
+    // Each record's data serializes to ~1.1KB compact JSON; the pretty-printed
+    // 50-record default page measures ~70,100 bytes. Budget pinned at 128KB.
+    const recordData = (i: number) => ({
+      title: `Record ${i} — long-form captured artifact title with descriptive suffix`,
+      url: `https://example.com/articles/${i}/full-text-analysis`,
+      status: 'active',
+      score: 0.87,
+      tags: ['research', 'agent', 'longform'],
+      notes: 'N'.padEnd(700, 'Detailed extraction notes covering methodology, source reliability, cross-references and follow-up actions. '),
+      summary: 'S'.padEnd(180, 'Concise summary text for the record body. '),
+    })
+    vi.mocked(recordService.queryRecords).mockResolvedValue({
+      records: Array.from({ length: 50 }, (_, i) => ({
+        id: i + 1,
+        status: 'active',
+        created_at: '2026-08-01T12:34:56.000Z',
+        updated_at: '2026-08-02T01:23:45.000Z',
+        data: recordData(i + 1),
+      })),
+      total: 50,
+      limit: 50,
+      offset: 0,
+    } as never)
+
+    const result = await registeredTools.get('hutch_query_records')!({ slug: 'research' }) as { content: { text: string }[] }
+    const bytes = Buffer.byteLength(result.content[0].text, 'utf8')
+    expect(bytes).toBeLessThan(128 * 1024)
+    // Sanity: the fixture really carries ~50KB+ of payload.
+    expect(bytes).toBeGreaterThan(50 * 1024)
+  })
+})
+
 describe('tool input schemas and descriptions', () => {
   it('caps import content at 10MB in the zod schema (mirrors the service-level cap)', () => {
     createMcpServer('user-1', 'org-test', 'https://example.test')

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { DrizzleQueryError } from "drizzle-orm";
 import { z } from "zod";
 import * as collectionService from "@/lib/services/collections";
 import * as recordService from "@/lib/services/records";
@@ -61,6 +62,22 @@ function summarizedWriteResponse(result: object, collectionUrl: (slug: string) =
   return textResponse(summary ? `${summary}\n\n${json}` : json);
 }
 
+/**
+ * Database-layer failures whose messages leak driver internals (SQL text,
+ * bound params) and must never reach the MCP client verbatim.
+ *
+ * drizzle-orm 0.45 throws DrizzleQueryError with message
+ * "Failed query: <sql>\nparams: <params>". Note the class never assigns
+ * `this.name`, so at runtime `err.name` is plain "Error" — the instanceof
+ * and message checks are the ones that actually fire; the name check is
+ * kept for errors crossing realm/bundle boundaries where instanceof fails.
+ */
+function isDatabaseError(err: unknown): boolean {
+  if (err instanceof DrizzleQueryError) return true;
+  if (!(err instanceof Error)) return false;
+  return err.name === "DrizzleQueryError" || /^Failed query/i.test(err.message);
+}
+
 function collectionNotFound(slug: string): McpToolResponse {
   return errorResponse(
     `Collection '${slug}' not found. Call hutch_list_collections to see available slugs, or use hutch_store_records to create a new one by writing to it.`
@@ -78,7 +95,33 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
 
   const collectionUrl = (slug: string) => `${baseUrl}/c/${slug}`;
 
-  server.registerTool(
+  /**
+   * Error-hygiene chokepoint for every tool registration. If a handler
+   * throws a database-layer error, the MCP SDK would otherwise stringify
+   * it into the tool output — leaking raw SQL and bound params to the
+   * client. Catch those here: log the real error server-side, return a
+   * generic isError response. Every OTHER throw is rethrown unchanged so
+   * intentional validation errors (e.g. "Unsupported filter operator …"
+   * from the query engine) still reach the client verbatim via the SDK.
+   */
+  const registerTool: McpServer["registerTool"] = (name, config, handler) => {
+    const wrapped = async (...args: unknown[]) => {
+      try {
+        return await (handler as (...a: unknown[]) => Promise<McpToolResponse>)(...args);
+      } catch (err) {
+        if (isDatabaseError(err)) {
+          console.error(`[mcp] ${name} database error:`, err);
+          return errorResponse(
+            `${name} failed while accessing the database. Try again or adjust the inputs.`
+          );
+        }
+        throw err;
+      }
+    };
+    return server.registerTool(name, config, wrapped as typeof handler);
+  };
+
+  registerTool(
     "hutch_list_collections",
     {
       title: "List Collections",
@@ -107,7 +150,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_get_collection",
     {
       title: "Get Collection",
@@ -122,7 +165,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_describe_collection",
     {
       title: "Describe Collection",
@@ -137,7 +180,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_store_records",
     {
       title: "Store Records",
@@ -164,7 +207,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_query_records",
     {
       title: "Query Records",
@@ -204,7 +247,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_search",
     {
       title: "Search Records",
@@ -221,7 +264,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_collection_stats",
     {
       title: "Collection Stats",
@@ -236,7 +279,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_export_records",
     {
       title: "Export Records",
@@ -267,7 +310,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_import_records",
     {
       title: "Import Records",
@@ -292,7 +335,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_update_collection",
     {
       title: "Update Collection",
@@ -315,7 +358,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_delete_collection",
     {
       title: "Delete Collection",
@@ -330,7 +373,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_update_record",
     {
       title: "Update Record",
@@ -350,7 +393,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_transform_records",
     {
       title: "Transform Records",
@@ -379,7 +422,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_delete_record",
     {
       title: "Delete Record",
@@ -399,7 +442,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_infer_schema",
     {
       title: "Infer Schema",
@@ -417,7 +460,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_update_schema",
     {
       title: "Update Schema",
@@ -441,7 +484,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_set_record_status",
     {
       title: "Set Record Status",
@@ -462,7 +505,7 @@ export function createMcpServer(userId: string, organizationId: string, baseUrl:
     }
   );
 
-  server.registerTool(
+  registerTool(
     "hutch_create_view",
     {
       title: "Create View",

--- a/src/lib/services/records.integration.test.ts
+++ b/src/lib/services/records.integration.test.ts
@@ -1,0 +1,669 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { fileURLToPath } from "node:url";
+import { Pool } from "pg";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { sql, eq, asc } from "drizzle-orm";
+import * as schema from "@/lib/db/schema";
+
+// ---------------------------------------------------------------------------
+// Real-Postgres integration tier. No mocks — every service call in this file
+// executes its actual generated SQL against a scratch database.
+//
+// Why this exists: three production bugs shipped because unit tests mock the
+// DB. (1) transform_records' rename SQL failed on real Postgres — untyped
+// bind params are ambiguous for `->`/`-` and fail outright in
+// jsonb_build_object (VARIADIC "any") under node-postgres ("could not
+// determine data type of parameter"). (2) transform with no ops silently
+// succeeded. (3) list_collections dumped full schemas. This tier's job:
+// every piece of generated SQL must actually run.
+//
+// Auto-skipped when HUTCH_TEST_DATABASE_URL is not set, so plain `npm test`
+// stays green without any infrastructure.
+//
+// To run locally:
+//
+//   createdb hutch_test
+//   HUTCH_TEST_DATABASE_URL=postgresql://localhost/hutch_test npm test
+//
+// DB wiring choice: service modules import `db` from `@/lib/db`, which builds
+// a pg Pool from process.env.HUTCH_DATABASE_URL at module-load time. Rather
+// than vi.mock'ing `@/lib/db` (which would swap out the very module chain we
+// are trying to exercise), we overwrite HUTCH_DATABASE_URL with the test URL
+// in beforeAll and only then dynamically import the service modules. This
+// file runs in its own vitest worker (the `integration` project), so the
+// override can't leak into unit tests, and the REAL `@/lib/db` pool — with
+// its production statement_timeout settings — runs against the scratch DB.
+// The suite's own drizzle client (for migrate/seed/truncate/asserts) is built
+// directly from HUTCH_TEST_DATABASE_URL and never touches `@/lib/db`.
+// ---------------------------------------------------------------------------
+
+const TEST_DB_URL = process.env.HUTCH_TEST_DATABASE_URL;
+
+const USER_ID = "integration-user";
+const USER_EMAIL = "integration@hutch.test";
+const ORG_ID = "integration-org";
+
+type RecordsService = typeof import("@/lib/services/records");
+type CollectionsService = typeof import("@/lib/services/collections");
+
+/** Narrow a service result to its success shape, failing loudly otherwise. */
+function ok<T>(result: T): Exclude<T, { error: unknown } | null | undefined> {
+  if (result == null || (typeof result === "object" && "error" in (result as object))) {
+    throw new Error(`Expected success result, got: ${JSON.stringify(result)}`);
+  }
+  return result as Exclude<T, { error: unknown } | null | undefined>;
+}
+
+describe.skipIf(!TEST_DB_URL)("services against real Postgres", () => {
+  let testPool: Pool;
+  let testDb: NodePgDatabase<typeof schema>;
+  let appPool: Pool | undefined;
+  let recordsSvc: RecordsService;
+  let collectionsSvc: CollectionsService;
+
+  beforeAll(async () => {
+    // Point the app module chain at the scratch DB BEFORE importing it.
+    process.env.HUTCH_DATABASE_URL = TEST_DB_URL;
+
+    testPool = new Pool({ connectionString: TEST_DB_URL });
+    testDb = drizzle(testPool, { schema });
+
+    // Apply the repo's real migration chain to the scratch database.
+    const migrationsFolder = fileURLToPath(new URL("../../../drizzle", import.meta.url));
+    await migrate(testDb, { migrationsFolder });
+
+    // Now that the env var points at the scratch DB, load the real modules.
+    recordsSvc = await import("@/lib/services/records");
+    collectionsSvc = await import("@/lib/services/collections");
+    const dbModule = await import("@/lib/db");
+    appPool = dbModule.db.$client as Pool;
+
+    // Minimal viable FK graph: one user, one org, one membership. Collections
+    // and collection_members rows are created by the services themselves.
+    await testDb
+      .insert(schema.user)
+      .values({ id: USER_ID, email: USER_EMAIL, name: "Integration" })
+      .onConflictDoNothing();
+    await testDb
+      .insert(schema.organizations)
+      .values({ id: ORG_ID, slug: "integration", name: "Integration", personal: true })
+      .onConflictDoNothing();
+    await testDb
+      .insert(schema.organizationMembers)
+      .values({ organizationId: ORG_ID, userId: USER_ID, role: "admin" })
+      .onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    // Cascades to records, views, collection_members, collection_invitations.
+    // The seeded user/org rows survive across tests.
+    await testDb.execute(sql`TRUNCATE collections RESTART IDENTITY CASCADE`);
+  });
+
+  afterAll(async () => {
+    await appPool?.end();
+    await testPool?.end();
+  });
+
+  /** Store records through the real service, returning the collection slug. */
+  async function seed(collection: string, recs: Record<string, unknown>[]): Promise<string> {
+    const result = ok(await recordsSvc.createRecords(USER_ID, ORG_ID, { collection, records: recs }));
+    return (result as { collection: { slug: string } }).collection.slug;
+  }
+
+  /** Read a collection's live records straight from the scratch DB. */
+  async function rawData(slug: string): Promise<Record<string, unknown>[]> {
+    const [coll] = await testDb.select().from(schema.collections).where(eq(schema.collections.slug, slug));
+    const rows = await testDb
+      .select()
+      .from(schema.records)
+      .where(eq(schema.records.collectionId, coll.id))
+      .orderBy(asc(schema.records.id));
+    return rows.filter((r) => r.deletedAt === null).map((r) => r.data as Record<string, unknown>);
+  }
+
+  async function query(slug: string, params: Parameters<RecordsService["queryRecords"]>[2]) {
+    return ok(await recordsSvc.queryRecords(slug, USER_ID, params));
+  }
+
+  // ── a. transformRecords ───────────────────────────────────────────────────
+
+  describe("transformRecords", () => {
+    it("rename_fields executes on real Postgres and moves values (the regression)", async () => {
+      const slug = await seed("transform_rename", [
+        { old_name: "keep-me", other: 1 },
+        { old_name: 42 },
+        { unrelated: true }, // lacks the field — must be untouched
+      ]);
+
+      const result = ok(
+        await recordsSvc.transformRecords(slug, USER_ID, { rename_fields: { old_name: "new_name" } }),
+      );
+      expect(result.updated).toBe(2);
+
+      const data = await rawData(slug);
+      expect(data[0]).toEqual({ new_name: "keep-me", other: 1 });
+      expect(data[1]).toEqual({ new_name: 42 });
+      expect(data[2]).toEqual({ unrelated: true });
+    });
+
+    it("remove_fields strips multiple fields in one statement", async () => {
+      const slug = await seed("transform_remove", [
+        { a: 1, b: 2, c: 3 },
+        { a: 4, c: 5 },
+      ]);
+
+      const result = ok(await recordsSvc.transformRecords(slug, USER_ID, { remove_fields: ["a", "b"] }));
+      expect(result.updated).toBeGreaterThan(0);
+
+      const data = await rawData(slug);
+      expect(data).toEqual([{ c: 3 }, { c: 5 }]);
+    });
+
+    it("set_field without filter overwrites every record", async () => {
+      const slug = await seed("transform_set_all", [{ x: 1 }, { x: 2 }]);
+
+      const result = ok(
+        await recordsSvc.transformRecords(slug, USER_ID, {
+          set_field: { field: "flag", value: { nested: true } },
+        }),
+      );
+      expect(result.updated).toBe(2);
+
+      const data = await rawData(slug);
+      expect(data).toEqual([
+        { x: 1, flag: { nested: true } },
+        { x: 2, flag: { nested: true } },
+      ]);
+    });
+
+    it("set_field with filter only touches matching records", async () => {
+      const slug = await seed("transform_set_filtered", [
+        { status: "active", n: 1 },
+        { status: "done", n: 2 },
+      ]);
+
+      const result = ok(
+        await recordsSvc.transformRecords(slug, USER_ID, {
+          set_field: { field: "archived", value: true, filter: { status: "done" } },
+        }),
+      );
+      expect(result.updated).toBe(1);
+
+      const data = await rawData(slug);
+      expect(data).toEqual([
+        { status: "active", n: 1 },
+        { status: "done", n: 2, archived: true },
+      ]);
+    });
+
+    it("rejects a transform with no operations (regression: silent no-op success)", async () => {
+      const slug = await seed("transform_empty", [{ a: 1 }]);
+      const result = await recordsSvc.transformRecords(slug, USER_ID, {});
+      expect(result).toMatchObject({ status: 400 });
+      expect(result && "error" in result && result.error).toMatch(/No transform operation/);
+    });
+  });
+
+  // ── b. filter operators via queryRecords ──────────────────────────────────
+
+  describe("filter operators", () => {
+    let slug: string;
+
+    beforeEach(async () => {
+      slug = await seed("operators", [
+        { n: 5, s: "apple", tag: "a" },
+        { n: 10, s: "banana", tag: "b" },
+        { n: 15, s: "cherry" }, // no tag
+        { n: "not-a-number", s: 99 }, // mixed types on n and s
+        { note: "50%_off" },
+        { note: "50x_off" },
+        { note: "Hello World" },
+      ]);
+    });
+
+    // Batch-inserted rows share a created_at, so result order is not
+    // deterministic — assertions compare value sets sorted numerically.
+    async function matchedN(filter: Record<string, unknown>): Promise<unknown[]> {
+      const result = await query(slug, { filter });
+      if (!("records" in result)) throw new Error("expected records shape");
+      return result.records
+        .map((r) => (r.data as Record<string, unknown>).n)
+        .sort((a, b) => Number(a) - Number(b));
+    }
+
+    it("$gt/$gte/$lt/$lte with number operands skip non-numeric values without erroring", async () => {
+      expect(await matchedN({ n: { $gt: 5 } })).toEqual([10, 15]);
+      expect(await matchedN({ n: { $gte: 10 } })).toEqual([10, 15]);
+      expect(await matchedN({ n: { $lt: 10 } })).toEqual([5]);
+      expect(await matchedN({ n: { $lte: 10 } })).toEqual([5, 10]);
+      expect(await matchedN({ n: { $gte: 5, $lt: 15 } })).toEqual([5, 10]);
+    });
+
+    it("$gt/$gte/$lt/$lte with string operands compare lexicographically on string values only", async () => {
+      const result = await query(slug, { filter: { s: { $gte: "banana" } } });
+      if (!("records" in result)) throw new Error("expected records shape");
+      const values = result.records.map((r) => (r.data as Record<string, unknown>).s).sort();
+      expect(values).toEqual(["banana", "cherry"]); // s: 99 (number) excluded, "apple" < "banana"
+
+      const below = await query(slug, { filter: { s: { $lt: "banana" } } });
+      if (!("records" in below)) throw new Error("expected records shape");
+      expect(below.records.map((r) => (r.data as Record<string, unknown>).s)).toEqual(["apple"]);
+    });
+
+    it("$ne matches differing values AND records missing the field", async () => {
+      const result = await query(slug, { filter: { tag: { $ne: "a" } } });
+      if (!("records" in result)) throw new Error("expected records shape");
+      const tags = result.records.map((r) => (r.data as Record<string, unknown>).tag);
+      expect(tags).not.toContain("a");
+      expect(result.total).toBe(6); // everything except the tag: "a" record
+    });
+
+    it("$in matches listed values; $nin includes records missing the field", async () => {
+      const inResult = await query(slug, { filter: { tag: { $in: ["a", "b"] } } });
+      if (!("records" in inResult)) throw new Error("expected records shape");
+      expect(inResult.total).toBe(2);
+
+      const ninResult = await query(slug, { filter: { tag: { $nin: ["a"] } } });
+      if (!("records" in ninResult)) throw new Error("expected records shape");
+      expect(ninResult.total).toBe(6); // tag: "b" plus the five records without tag
+
+      const numericIn = await query(slug, { filter: { n: { $in: [5, 15] } } });
+      if (!("records" in numericIn)) throw new Error("expected records shape");
+      expect(numericIn.total).toBe(2);
+    });
+
+    it("$exists true/false split the collection by field presence", async () => {
+      const withTag = await query(slug, { filter: { tag: { $exists: true } } });
+      if (!("records" in withTag)) throw new Error("expected records shape");
+      expect(withTag.total).toBe(2);
+
+      const withoutTag = await query(slug, { filter: { tag: { $exists: false } } });
+      if (!("records" in withoutTag)) throw new Error("expected records shape");
+      expect(withoutTag.total).toBe(5);
+    });
+
+    it("$contains is case-insensitive substring", async () => {
+      const result = await query(slug, { filter: { note: { $contains: "hello w" } } });
+      if (!("records" in result)) throw new Error("expected records shape");
+      expect(result.total).toBe(1);
+      expect((result.records[0].data as Record<string, unknown>).note).toBe("Hello World");
+    });
+
+    it("$contains escapes % and _ so they match literally", async () => {
+      // Unescaped, "0%_o" would ILIKE-match both "50%_off" and "50x_off".
+      const result = await query(slug, { filter: { note: { $contains: "0%_o" } } });
+      if (!("records" in result)) throw new Error("expected records shape");
+      expect(result.total).toBe(1);
+      expect((result.records[0].data as Record<string, unknown>).note).toBe("50%_off");
+    });
+
+    it("plain values use JSONB containment", async () => {
+      const result = await query(slug, { filter: { tag: "a" } });
+      if (!("records" in result)) throw new Error("expected records shape");
+      expect(result.total).toBe(1);
+      expect((result.records[0].data as Record<string, unknown>).n).toBe(5);
+    });
+
+    it("operators on a wholly mixed-type field never raise SQL errors", async () => {
+      // n is number in some records, string in one, absent in others — every
+      // operator must execute cleanly against real Postgres.
+      for (const filter of [
+        { n: { $gt: 0 } },
+        { n: { $lte: "zzz" } },
+        { n: { $ne: 5 } },
+        { n: { $in: [5, "not-a-number"] } },
+        { n: { $nin: [10] } },
+        { n: { $exists: true } },
+        { s: { $contains: "err" } },
+      ]) {
+        const result = await query(slug, { filter });
+        expect("records" in result).toBe(true);
+      }
+    });
+  });
+
+  // ── c. aggregations ───────────────────────────────────────────────────────
+
+  describe("aggregations", () => {
+    let slug: string;
+
+    beforeEach(async () => {
+      slug = await seed("aggregations", [
+        { team: "red", score: 10, label: "alpha" },
+        { team: "red", score: 30, label: "beta" },
+        { team: "blue", score: 5, label: "alpha" },
+        { team: "blue", score: "n/a", label: "gamma" }, // non-numeric score
+        { team: "text-only", score: "high" }, // group with ZERO numeric values
+      ]);
+    });
+
+    async function aggregated(params: Parameters<RecordsService["queryRecords"]>[2]) {
+      const result = await query(slug, params);
+      if (!("results" in result)) throw new Error("expected aggregation shape");
+      return result.results as Record<string, unknown>[];
+    }
+
+    it("count", async () => {
+      const rows = await aggregated({ aggregate: { total: "count" } });
+      expect(rows).toEqual([{ total: 5 }]);
+    });
+
+    it("min and max (text-based, per current engine semantics)", async () => {
+      const rows = await aggregated({ aggregate: { lo: { min: "label" }, hi: { max: "label" } } });
+      expect(rows).toEqual([{ lo: "alpha", hi: "gamma" }]);
+    });
+
+    it("distinct", async () => {
+      const rows = await aggregated({ aggregate: { teams: { distinct: "team" } } });
+      expect((rows[0].teams as string[]).sort()).toEqual(["blue", "red", "text-only"]);
+    });
+
+    it("sum and avg aggregate only numeric values", async () => {
+      const rows = await aggregated({ aggregate: { total: { sum: "score" }, mean: { avg: "score" } } });
+      // 10 + 30 + 5; "n/a" and "high" are ignored by the jsonb_typeof guard.
+      expect(Number(rows[0].total)).toBe(45);
+      expect(Number(rows[0].mean)).toBeCloseTo(15);
+    });
+
+    it("avg of an all-non-numeric group returns null (not an error)", async () => {
+      const rows = await aggregated({
+        groupBy: "team",
+        aggregate: { mean: { avg: "score" }, total: { sum: "score" } },
+      });
+      const textOnly = rows.find((r) => r.team === "text-only");
+      expect(textOnly).toBeDefined();
+      expect(textOnly!.mean).toBeNull();
+      expect(textOnly!.total).toBeNull();
+    });
+
+    it("group_by groups with counts, ordered by group key", async () => {
+      const rows = await aggregated({ groupBy: "team", aggregate: { n: "count" } });
+      expect(rows).toEqual([
+        { team: "blue", n: 2 },
+        { team: "red", n: 2 },
+        { team: "text-only", n: 1 },
+      ]);
+    });
+
+    it("time_bucket buckets by created_at", async () => {
+      // Push two records into yesterday's bucket directly in the DB.
+      const [coll] = await testDb.select().from(schema.collections).where(eq(schema.collections.slug, slug));
+      await testDb.execute(sql`
+        UPDATE records SET created_at = created_at - interval '1 day'
+        WHERE collection_id = ${coll.id}
+          AND id IN (SELECT id FROM records WHERE collection_id = ${coll.id} ORDER BY id ASC LIMIT 2)
+      `);
+
+      const rows = await aggregated({ timeBucket: "day", aggregate: { n: "count" } });
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toHaveProperty("time_bucket");
+      expect(rows.map((r) => Number(r.n))).toEqual([2, 3]); // ordered by bucket ASC
+    });
+  });
+
+  // ── d. sort, projection, pagination ───────────────────────────────────────
+
+  describe("sort, projection, pagination", () => {
+    it("sorts on a data field both directions", async () => {
+      const slug = await seed("sorting", [{ name: "carol" }, { name: "alice" }, { name: "bob" }]);
+
+      const ascResult = await query(slug, { sort: "name" });
+      if (!("records" in ascResult)) throw new Error("expected records shape");
+      expect(ascResult.records.map((r) => (r.data as Record<string, unknown>).name)).toEqual([
+        "alice",
+        "bob",
+        "carol",
+      ]);
+
+      const descResult = await query(slug, { sort: "-name" });
+      if (!("records" in descResult)) throw new Error("expected records shape");
+      expect(descResult.records.map((r) => (r.data as Record<string, unknown>).name)).toEqual([
+        "carol",
+        "bob",
+        "alice",
+      ]);
+    });
+
+    it("fields projection keeps only requested top-level keys", async () => {
+      const slug = await seed("projection", [{ title: "T", url: "u", body: "long text", extra: 1 }]);
+
+      const result = await query(slug, { fields: ["title", "url"] });
+      if (!("records" in result)) throw new Error("expected records shape");
+      expect(result.records[0].data).toEqual({ title: "T", url: "u" });
+    });
+
+    it("pagination reports total / has_more / next_offset correctly", async () => {
+      // Single-digit i values sort deterministically as text (data->>'i').
+      const slug = await seed(
+        "pagination",
+        Array.from({ length: 5 }, (_, i) => ({ i: String(i) })),
+      );
+
+      const page1 = await query(slug, { limit: 2, offset: 0, sort: "i" });
+      if (!("records" in page1)) throw new Error("expected records shape");
+      expect(page1.count).toBe(2);
+      expect(page1.total).toBe(5);
+      expect(page1.has_more).toBe(true);
+      expect(page1.next_offset).toBe(2);
+
+      const page3 = await query(slug, { limit: 2, offset: 4, sort: "i" });
+      if (!("records" in page3)) throw new Error("expected records shape");
+      expect(page3.count).toBe(1);
+      expect(page3.total).toBe(5);
+      expect(page3.has_more).toBe(false);
+      expect(page3.next_offset).toBeNull();
+    });
+  });
+
+  // ── e. upsert via unique_key ──────────────────────────────────────────────
+
+  describe("createRecords upsert with unique_key", () => {
+    async function upsertCollection(name: string): Promise<string> {
+      const created = ok(
+        await collectionsSvc.createCollection(USER_ID, ORG_ID, { name, unique_key: ["sku"] }),
+      );
+      return created.collection.slug;
+    }
+
+    it("on_conflict replace (default) overwrites the matching record", async () => {
+      const slug = await upsertCollection("Upsert Replace");
+      await recordsSvc.createRecords(USER_ID, ORG_ID, {
+        collection: "Upsert Replace",
+        records: [{ sku: "a1", qty: 1, legacy: true }],
+      });
+      const second = ok(
+        await recordsSvc.createRecords(USER_ID, ORG_ID, {
+          collection: "Upsert Replace",
+          records: [{ sku: "a1", qty: 2 }],
+        }),
+      ) as { results: { action: string }[] };
+      expect(second.results[0].action).toBe("updated");
+
+      const data = await rawData(slug);
+      expect(data).toEqual([{ sku: "a1", qty: 2 }]); // legacy gone — full replace
+    });
+
+    it("on_conflict merge shallow-merges into the existing record", async () => {
+      const slug = await upsertCollection("Upsert Merge");
+      await recordsSvc.createRecords(USER_ID, ORG_ID, {
+        collection: "Upsert Merge",
+        records: [{ sku: "a1", qty: 1, keep: "yes" }],
+      });
+      const second = ok(
+        await recordsSvc.createRecords(USER_ID, ORG_ID, {
+          collection: "Upsert Merge",
+          records: [{ sku: "a1", qty: 5 }],
+          on_conflict: "merge",
+        }),
+      ) as { results: { action: string }[] };
+      expect(second.results[0].action).toBe("updated");
+
+      const data = await rawData(slug);
+      expect(data).toEqual([{ sku: "a1", qty: 5, keep: "yes" }]);
+    });
+
+    it("on_conflict skip leaves the existing record untouched", async () => {
+      const slug = await upsertCollection("Upsert Skip");
+      await recordsSvc.createRecords(USER_ID, ORG_ID, {
+        collection: "Upsert Skip",
+        records: [{ sku: "a1", qty: 1 }],
+      });
+      const second = ok(
+        await recordsSvc.createRecords(USER_ID, ORG_ID, {
+          collection: "Upsert Skip",
+          records: [{ sku: "a1", qty: 99 }],
+          on_conflict: "skip",
+        }),
+      ) as { results: { action: string }[] };
+      expect(second.results[0].action).toBe("skipped");
+
+      const data = await rawData(slug);
+      expect(data).toEqual([{ sku: "a1", qty: 1 }]);
+    });
+
+    it("on_conflict error returns 409 and inserts nothing", async () => {
+      const slug = await upsertCollection("Upsert Error");
+      await recordsSvc.createRecords(USER_ID, ORG_ID, {
+        collection: "Upsert Error",
+        records: [{ sku: "a1", qty: 1 }],
+      });
+      const second = await recordsSvc.createRecords(USER_ID, ORG_ID, {
+        collection: "Upsert Error",
+        records: [{ sku: "a1", qty: 2 }],
+        on_conflict: "error",
+      });
+      expect(second).toMatchObject({ status: 409 });
+
+      const data = await rawData(slug);
+      expect(data).toEqual([{ sku: "a1", qty: 1 }]);
+    });
+
+    it("non-conflicting records still insert alongside upserts", async () => {
+      const slug = await upsertCollection("Upsert Mixed");
+      await recordsSvc.createRecords(USER_ID, ORG_ID, {
+        collection: "Upsert Mixed",
+        records: [{ sku: "a1", qty: 1 }],
+      });
+      const second = ok(
+        await recordsSvc.createRecords(USER_ID, ORG_ID, {
+          collection: "Upsert Mixed",
+          records: [{ sku: "a1", qty: 2 }, { sku: "b2", qty: 7 }],
+        }),
+      ) as { results: { action: string }[] };
+      expect(second.results.map((r) => r.action)).toEqual(["updated", "created"]);
+
+      const data = await rawData(slug);
+      expect(data).toEqual([
+        { sku: "a1", qty: 2 },
+        { sku: "b2", qty: 7 },
+      ]);
+    });
+  });
+
+  // ── f. export → import round trip ─────────────────────────────────────────
+
+  it("exportRecords CSV round-trips through importRecords via the real DB", async () => {
+    // Values chosen to survive CSV coercion: commas/quotes exercise RFC 4180
+    // quoting; the nested object is JSON-stringified into its cell.
+    const original = [
+      { title: "Hello, world", note: 'She said "hi"', qty: 3, meta: { deep: true } },
+      { title: "Second", qty: 1.5, flag: false },
+    ];
+    const sourceSlug = await seed("export_source", original);
+
+    const exported = ok(await recordsSvc.exportRecords(sourceSlug, USER_ID, { format: "csv" }));
+    expect(exported.format).toBe("csv");
+    expect(exported.count).toBe(2);
+    expect(exported.truncated).toBe(false);
+
+    // importRecords' inferred return union re-exposes the raw createRecords
+    // shape on the error path, so narrow the success shape explicitly.
+    const imported = ok(
+      await recordsSvc.importRecords(USER_ID, ORG_ID, {
+        collection: "export_target",
+        format: "csv",
+        content: exported.content,
+      }),
+    ) as { collection: { name: string; slug: string }; count: number; created: number };
+    expect(imported.count).toBe(2);
+    expect(imported.created).toBe(2);
+
+    const data = await rawData(imported.collection.slug);
+    // CSV export orders newest-first (created_at DESC); compare as sets.
+    expect(data).toHaveLength(2);
+    expect(data).toEqual(expect.arrayContaining(original));
+  });
+
+  // ── g. stats + describe ───────────────────────────────────────────────────
+
+  it("getCollectionStats runs its SQL and returns a sane shape", async () => {
+    const slug = await seed("stats", [
+      { a: 1, b: "x" },
+      { a: 2 },
+      { a: 3, b: "y", c: true },
+    ]);
+
+    const stats = ok(await collectionsSvc.getCollectionStats(slug, USER_ID));
+    expect(stats.record_count).toBe(3);
+    expect(stats.by_status).toEqual({ active: 3 });
+    expect(stats.first_created_at).toBeTruthy();
+    expect(stats.last_created_at).toBeTruthy();
+    expect(stats.approx_storage_bytes).toBeGreaterThan(0);
+    expect(stats.fields).toEqual([
+      { name: "a", count: 3, percent: 100 },
+      { name: "b", count: 2, percent: 66.7 },
+      { name: "c", count: 1, percent: 33.3 },
+    ]);
+  });
+
+  it("describeCollection samples real rows and reports fields", async () => {
+    const slug = await seed("describe", [
+      { title: "one", score: 10 },
+      { title: "two", score: 20 },
+    ]);
+
+    const described = ok(await collectionsSvc.describeCollection(slug, USER_ID));
+    expect(described.recordCount).toBe(2);
+    const byName = new Map(described.fields.map((f) => [f.name, f]));
+    expect(byName.get("title")?.frequency).toBe(1);
+    const score = byName.get("score");
+    expect(score?.min).toBe(10);
+    expect(score?.max).toBe(20);
+    expect(score?.avg).toBe(15);
+  });
+
+  // ── h. full-text search ───────────────────────────────────────────────────
+
+  describe("full-text search", () => {
+    it("queryRecords search param matches via tsvector", async () => {
+      const slug = await seed("search_local", [
+        { body: "the quick brown fox jumps" },
+        { body: "an unrelated sentence" },
+      ]);
+
+      const hit = await query(slug, { search: "fox" });
+      if (!("records" in hit)) throw new Error("expected records shape");
+      expect(hit.total).toBe(1);
+      expect((hit.records[0].data as Record<string, unknown>).body).toContain("fox");
+
+      const miss = await query(slug, { search: "zeppelin" });
+      if (!("records" in miss)) throw new Error("expected records shape");
+      expect(miss.total).toBe(0);
+    });
+
+    it("searchGlobal finds matches across accessible collections", async () => {
+      await seed("search_one", [{ text: "vintage synthesizer restoration" }]);
+      await seed("search_two", [{ text: "synthesizer patch library" }, { text: "gardening tips" }]);
+
+      const result = await recordsSvc.searchGlobal(USER_ID, "synthesizer");
+      expect(result.results).toHaveLength(2);
+      const totalMatches = result.results.reduce((n, g) => n + g.matches, 0);
+      expect(totalMatches).toBe(2);
+
+      const none = await recordsSvc.searchGlobal(USER_ID, "nonexistentterm");
+      expect(none.results).toHaveLength(0);
+    });
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -17,14 +17,17 @@ export default defineConfig({
         },
       },
       {
-        // Integration tests hit real network endpoints (MinIO); happy-dom's
-        // browser-emulating fetch corrupts SigV4-signed requests, so these
-        // run in the plain node environment.
+        // Integration tests hit real infrastructure (Postgres via
+        // HUTCH_TEST_DATABASE_URL), so they run in the plain node
+        // environment. fileParallelism is off because every integration
+        // file shares one scratch database and truncates between tests —
+        // parallel files would clobber each other's rows.
         extends: true,
         test: {
           name: 'integration',
           environment: 'node',
           include: ['src/**/*.integration.test.ts'],
+          fileParallelism: false,
         },
       },
     ],


### PR DESCRIPTION
Testing tier motivated by the transform_records bug class (SQL that unit mocks never execute):

- 34 integration tests run every service SQL path against a scratch Postgres (filter operators, aggregations, transforms, upserts, CSV round-trip, stats, tsvector). Skip cleanly without HUTCH_TEST_DATABASE_URL; CI gains a postgres:16 service so they run on every PR.
- smoke.ts SMOKE_FULL=1: initialize → tools/list (18 titled tools, read hints) → store/query/transform/export/delete loop against a running server.
- Error-hygiene chokepoint: DB-layer errors return a clean message instead of leaking driver SQL; validation errors pass through verbatim.
- Tool-surface snapshot + response-size budget tests.

344 tests passing with Postgres, 310+34 skipped without; tsc clean.

https://claude.ai/code/session_011SVZ6PMLVWrqy2KddwXKED