### PR TITLE
Add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Enables weekly Dependabot version updates for npm (minor/patch grouped into a single PR) and GitHub Actions. Dependabot alerts and automated security fixes were enabled on the repo settings side.

https://claude.ai/code/session_01XCb3XUNpkWrJc7kYBUeGXJ