### PR TITLE
Bump base image to node:26-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:22-alpine AS base
+FROM node:26-alpine AS base
 RUN apk add --no-cache libc6-compat
 
 # ---- deps -----------------------------------------------------------------


### PR DESCRIPTION
Matches the Dependabot bump waiting in hutchdb-cloud (#21); the
Dockerfile is parity-checked between the repos so Core moves first.

Claude-Session: https://claude.ai/code/session_014PoWkWqVUK72TA5NSQGMkL
