### PR TITLE
Fix numeric sort on data fields: compare as jsonb, not text

### DIFF
--- a/src/lib/db/queries.test.ts
+++ b/src/lib/db/queries.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const { selectLimit, selectOffset, dbExecute } = vi.hoisted(() => ({
+const { selectLimit, selectOffset, dbExecute, orderByCapture } = vi.hoisted(() => ({
   selectLimit: vi.fn(),
   selectOffset: vi.fn(),
   dbExecute: vi.fn(),
+  orderByCapture: vi.fn(),
 }))
 
 // Drizzle's query builder is chainable: each clause returns an object with
@@ -16,7 +17,10 @@ function buildChain(): any {
     where: vi.fn(() => chain),
     innerJoin: vi.fn(() => chain),
     leftJoin: vi.fn(() => chain),
-    orderBy: vi.fn(() => chain),
+    orderBy: vi.fn((clause) => {
+      orderByCapture(clause)
+      return chain
+    }),
     limit: selectLimit,
   }
   return chain
@@ -324,6 +328,34 @@ describe('queryRecords field projection', () => {
 
     const result = await queryRecords({ collectionId: 1 })
     expect('records' in result && result.records[0].data).toEqual({ a: 1, b: 2 })
+  })
+})
+
+describe('queryRecords sort', () => {
+  it('sorts data fields as jsonb values so numbers compare numerically, not as text', async () => {
+    selectLimit.mockReturnValue({ offset: selectOffset })
+    selectOffset.mockResolvedValue([])
+
+    await queryRecords({ collectionId: 1, sort: '-price' })
+
+    const { sql: rendered, params } = render(orderByCapture.mock.calls[0][0])
+    // `->` keeps jsonb typing (numeric comparison); `->>` casts to text and
+    // sorts numbers lexicographically ("12" < "3" < "5").
+    expect(rendered).toContain('->')
+    expect(rendered).not.toContain('->>')
+    expect(rendered.toLowerCase()).toContain('desc nulls last')
+    expect(params).toEqual(['price'])
+  })
+
+  it('ascending data-field sort also uses jsonb comparison', async () => {
+    selectLimit.mockReturnValue({ offset: selectOffset })
+    selectOffset.mockResolvedValue([])
+
+    await queryRecords({ collectionId: 1, sort: 'price' })
+
+    const { sql: rendered } = render(orderByCapture.mock.calls[0][0])
+    expect(rendered).not.toContain('->>')
+    expect(rendered.toLowerCase()).toContain('asc nulls last')
   })
 })
 

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -392,9 +392,11 @@ export async function queryRecords(params: QueryParams) {
     } else if (field === "updated_at") {
       orderBy = descending ? desc(records.updatedAt) : asc(records.updatedAt);
     } else if (/^[a-zA-Z0-9_]+$/.test(field)) {
+      // `->` keeps jsonb typing so numbers sort numerically; `->>` would cast
+      // to text and sort them lexicographically ("12" < "3" < "5").
       orderBy = descending
-        ? sql`${records.data}->>${field} DESC NULLS LAST`
-        : sql`${records.data}->>${field} ASC NULLS LAST`;
+        ? sql`${records.data}->${field} DESC NULLS LAST`
+        : sql`${records.data}->${field} ASC NULLS LAST`;
     } else {
       orderBy = desc(records.createdAt);
     }


### PR DESCRIPTION
## Summary
- `hutch_query_records` sorted data fields with `data->>field`, which extracts jsonb values as text — numeric fields sorted lexicographically (`"12" < "3" < "5"`), so `sort: "price"` returned 12, 3, 5.
- Switch to `data->field` to keep jsonb typing: numbers compare numerically, strings by collation. Missing keys still sort last via `NULLS LAST`.
- Found via a live end-to-end smoke test of the MCP surface ahead of the connectors-directory submission.

## Testing
- Two new regression tests in `queries.test.ts` assert the generated ORDER BY SQL uses `->` (written first, confirmed failing against the old code).
- Full suite: 312 passed.

https://claude.ai/code/session_01VhpZt1Xk3AeGrpzYyRPcZf